### PR TITLE
Make sure we link to articles in the public handbook

### DIFF
--- a/_articles/onboarding.md
+++ b/_articles/onboarding.md
@@ -81,7 +81,7 @@ Look at this work as a power multiplier, you are helping someone gain a firm fou
   - UAT meeting
   - Demo Day / All Hands
 - Read some docs
-  - [Our definition(s) of done](https://login-handbook.app.cloud.gov/articles/definition-of-done.html)
+  - [Our definition(s) of done]({% link _articles/definition-of-done.md %})
   - [Login.gov design guide documentation](https://design.login.gov/)
 - Write some code
   - Assign yourself a Jira ticket

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'HTML' do
       it 'is a well-behaved page' do
         aggregate_failures do
           expect(doc).to have_unique_ids
+          expect(doc).to link_internally_for_handbook_articles
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,5 @@ def file_at(path)
     File.new(full_path.to_s)
   elsif full_path.directory?
     File.new(full_path.join('index.html').to_s)
-  else
-    fail "could not locate file named #{path}"
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -24,3 +24,22 @@ RSpec::Matchers.define :have_unique_ids do
   end
 end
 
+RSpec::Matchers.define :link_internally_for_handbook_articles do
+  articles = Set.new
+
+  match do |actual|
+    doc = actual
+
+    doc.css('a[href*="login-handbook.app.cloud.gov"]').each do |a|
+      path = URI(a[:href]).path
+
+      articles << path if file_at(path)
+
+      expect(articles).to be_empty
+    end
+  end
+
+  failure_message do |actual|
+    "expected that #{actual.url} would not link to external version of articles in this handbook, but found:\n#{articles.to_a.join("\n")}"
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -34,9 +34,9 @@ RSpec::Matchers.define :link_internally_for_handbook_articles do
       path = URI(a[:href]).path
 
       articles << path if file_at(path)
-
-      expect(articles).to be_empty
     end
+
+    expect(articles).to be_empty
   end
 
   failure_message do |actual|


### PR DESCRIPTION
- As we migrate we link in to the old handbook. This adds a spec that
  will fail if we continue to link to the old article after already
  migrating it