### PR TITLE
Fix private handbook matcher to allow links to root

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -32,6 +32,7 @@ RSpec::Matchers.define :link_internally_for_handbook_articles do
 
     doc.css('a[href*="login-handbook.app.cloud.gov"]').each do |a|
       path = URI(a[:href]).path
+      next if path == '/'
 
       articles << path if file_at(path)
     end


### PR DESCRIPTION
The repos page links to the private handbook's URL to show what site it goes to, and links to the root.

The "private handbook lint" script makes sure that if we link to the old handbook, the corresponding page should not exist.

However, we kind of need to have a root page, so that's a special case, so I updated the matcher to skip that