### PR TITLE
Show last modified date (from git) on handbook pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "kramdown", ">= 2.3.0"
 
 group :jekyll_plugins do
   gem "jekyll-redirect-from"
+  gem "jekyll-last-modified-at"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
@@ -70,6 +73,7 @@ GEM
     parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (4.0.5)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -111,6 +115,7 @@ DEPENDENCIES
   activesupport
   html-proofer
   jekyll (~> 4)
+  jekyll-last-modified-at
   jekyll-redirect-from
   kramdown (>= 2.3.0)
   nokogiri

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ copy_to_destination:
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-last-modified-at
 
 exclude:
   - CONTRIBUTING.md

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,6 +56,7 @@
             <a href="#">Return to top</a>
           </div>
           <div class="grid-col flex-auto">
+            This page was last modified on {{ page.last_modified_at | date: '%b %e, %Y' }}
             <a href="{{ site.github_repo_url }}/edit/master/{{ page.path }}" class="usa-button usa-button--outline">Edit this page</a>
           </div>
         </div>

--- a/federalist.json
+++ b/federalist.json
@@ -1,0 +1,3 @@
+{
+  "fullClone": true
+}


### PR DESCRIPTION
- Takes advantage of new federalist config to do full clone

cc @davemcorwin

Example:

<img width="586" alt="Screen Shot 2020-09-22 at 11 36 04 AM" src="https://user-images.githubusercontent.com/458784/93923319-125d8900-fcc8-11ea-8a77-0a0a1f93806c.png">
