### PR TITLE
Add Partnerships specific onboarding tasks

### DIFF
--- a/_articles/deploying-sp-to-prod.md
+++ b/_articles/deploying-sp-to-prod.md
@@ -2,7 +2,7 @@
 title: "Deploying a Partner Service Provider Config to Production"
 layout: article
 description: "Process and proceeders when deploying a partner service provider config to production"
-category: AppDev
+category: Partnerships
 ---
 
 Here is a list of items that need to be completed to deploy the configuration for a partner SP (Service Provider) to Production.

--- a/_articles/onboarding.md
+++ b/_articles/onboarding.md
@@ -60,7 +60,7 @@ Look at this work as a power multiplier, you are helping someone gain a firm fou
 
 ## For Partnerhsips team members
 
-- Check out the [Partnerships Area of the handbook](https://login-handbook.app.cloud.gov/articles/partnerships.html)
+- Check out the [Partnerships Area of the handbook]({{site.baseurl}}/#partnerships)
 - Be sure to join the main Slack channels for our team, `#login` and `#login-partnerships`.
 - Add the following email address to your Google Calendar to see the Login Partnerships Team Calendar: `gsa.gov_6ovul6pcsmgd40o8pqn7qmge5g@group.calendar.google.com`
 - Add the user to [Hubspot](https://app.hubspot.com/settings/5531666/users)

--- a/_articles/onboarding.md
+++ b/_articles/onboarding.md
@@ -58,6 +58,14 @@ Look at this work as a power multiplier, you are helping someone gain a firm fou
 - Familiarize yourself with the [Login.gov Design System](https://design.login.gov/)
 - Familiarize yourself with the [Login.gov UX Drive Folders](https://drive.google.com/drive/folders/12qRTGijG9oOU8FRvZfK30qAN4v8LCzHG)
 
+## For Partnerhsips team members
+
+- Check out the [Partnerships Area of the handbook](https://login-handbook.app.cloud.gov/articles/partnerships.html)
+- Be sure to join the main Slack channels for our team, `#login` and `#login-partnerships`.
+- Add the following email address to your Google Calendar to see the Login Partnerships Team Calendar: `gsa.gov_6ovul6pcsmgd40o8pqn7qmge5g@group.calendar.google.com`
+- Add the user to [Hubspot](https://app.hubspot.com/settings/5531666/users)
+
+
 ## For AppDev Engineers
 
 ### In the first 30 days


### PR DESCRIPTION
This PR should replace Aaron's partnerships-specific onboarding doc (https://docs.google.com/document/d/1ip6oEA7sQjuNUbIrDvO11c1iDxapUyRkXE6SpGdOEak/edit#)

There were only a couple things in your list that weren't already in the public handbook.
When this looks :+1: to you we'll make a deprecation note in your GDoc and add a link to the handbook article: https://handbook.login.gov/articles/onboarding.html

This also begs the question if the linked "partnerships area" in the old, private handbook is still useful.
Aaron, should we move that document over also?