### PR TITLE
Fix list formatting for engineering definition of done

### DIFF
--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -18,7 +18,7 @@ Expect this DoD to change over time.
 - Ensure that our accessibility posture has been maintained or improved, preferably via automated `aXe` tests
 - All code and tests have been merged to master in GitHub repo
 - The `application.yml` configurations have been updated as needed in deployed environments
-Database indexes exist for any new queries
+- Database indexes exist for any new queries
 - The dashboard and sample SPs have been updated if necessary
 - If multiple database migrations are necessary, the database migrations have been performed
 - The story is deployed to Dev and/or INT environments


### PR DESCRIPTION
"Database indexes exist for any new queries" was not formatted as a list item, and would appear as combined with the previous list entry

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/97440594-06d03400-18fe-11eb-8d91-e612eaa71dfa.png)|![Screen Shot 2020-10-28 at 9 17 52 AM](https://user-images.githubusercontent.com/1779930/97440934-80682200-18fe-11eb-9110-7b01b6c0a496.png)

