### PR TITLE
Adding updated guidance for the translation process

### DIFF
--- a/_articles/appdev-i18n.md
+++ b/_articles/appdev-i18n.md
@@ -1,11 +1,23 @@
 ---
-title: "Internationalization (i18n)"
+title: "Translation process"
 layout: article
 description: "Process and guidelines for localization and string translation"
 category: AppDev
 ---
 
-Login.gov is currently available in English (American), Spanish (Mexican), and French (Canadian). This guide covers the tools available to translate the application, and the processes around introducing and translating new strings.
+Login.gov is currently available in English, Spanish, and French. This guide covers the tools available to translate the application, and the processes around introducing and translating new strings.
+
+## Translating content guidance
+
+Content on [secure.login.gov](https://secure.login.gov) and [login.gov](https://login.gov) is offered in the following languages:
+
+- English (U.S.)
+- French (Canada)
+- Spanish (Mexico)
+
+Translations are requested when content is added or updated on secure.login.gov and login.gov. You can find specific guidance on how to request translations in the [login.gov guidance document](https://docs.google.com/document/d/1-wNXxyvxrsUeHkMOfhBpoSTCTZULOXNlCkBdNxiLa3c/edit).
+
+**NOTE:** partners.login.gov and developers.login.gov are not expected to be translated.
 
 ## Internationalization APIs
 
@@ -43,9 +55,9 @@ As new screens are added or existing views are updated, the set of localized str
 
 ### When should strings be added?
 
-During the design process, the page copy may often change through iteration and feedback from the team and/or directly from the public. UX Team members will include layouts that display English, French and Spanish translations prior to handing off for Engineering to build. You can read more about that process here:  
+Content will change through the process of design iteration and feedback. It is up to the team's discretion when to add strings to `config/locales`, as opposed to using temporary text in an in-progress implementation.
 
-NOTE:
+However, keep in mind:
 
 - To avoid mistakenly leaving text as untranslated, it can help to introduce the string sooner rather than later.
 - The naming of the string key should ideally be generalized enough to not be tightly coupled with the exact text, which can improve resilience to changes in copy.
@@ -60,9 +72,3 @@ You can also take advantage of some automated tooling to assist in this process:
   - [See documentation for "Managing translation files"](https://github.com/18f/identity-idp#managing-translation-files)
 - Running `i18n-tasks add-missing` will generate placeholder values for all missing keys.
   - [See documentation for "`i18n-tasks add-missing`"](https://github.com/glebm/i18n-tasks#add-missing-keys)
-
-### How to request translations
-
-Translations are requested when content is added or updated on secure.login.gov and login.gov. You can find specific guidance on how to request translations in the [Login.gov guidance document](https://docs.google.com/document/d/16RVO4Gr1bBTt8RV14Jsi1U77lKCBWRagowZbjdsXQ0w/edit).
-
-You can find specific guidance on how to request translations in the [Login.gov guidance document](https://docs.google.com/document/d/16RVO4Gr1bBTt8RV14Jsi1U77lKCBWRagowZbjdsXQ0w/edit).

--- a/_articles/appdev-i18n.md
+++ b/_articles/appdev-i18n.md
@@ -5,7 +5,7 @@ description: "Process and guidelines for localization and string translation"
 category: AppDev
 ---
 
-Login.gov is currently available in English, Spanish, and French. This guide covers the tools available to translate the application, and the processes around introducing and translating new strings.
+Login.gov is currently available in English (American), Spanish (Mexican), and French (Canadian). This guide covers the tools available to translate the application, and the processes around introducing and translating new strings.
 
 ## Internationalization APIs
 
@@ -63,6 +63,6 @@ You can also take advantage of some automated tooling to assist in this process:
 
 ### How to request translations
 
-As mentioned earlier in this guide, the same YAML structure should exist for all supported locales, including the translated text values. Even if you are not a native speaker of the language, you should plan to include a translated value.
+Translations are requested when content is added or updated on secure.login.gov and login.gov. You can find specific guidance on how to request translations in the [Login.gov guidance document](https://docs.google.com/document/d/16RVO4Gr1bBTt8RV14Jsi1U77lKCBWRagowZbjdsXQ0w/edit).
 
 You can find specific guidance on how to request translations in the [Login.gov guidance document](https://docs.google.com/document/d/16RVO4Gr1bBTt8RV14Jsi1U77lKCBWRagowZbjdsXQ0w/edit).

--- a/_articles/appdev-i18n.md
+++ b/_articles/appdev-i18n.md
@@ -57,11 +57,7 @@ As new screens are added or existing views are updated, the set of localized str
 
 Content will change through the process of design iteration and feedback. It is up to the team's discretion when to add strings to `config/locales`, as opposed to using temporary text in an in-progress implementation.
 
-<<<<<<< HEAD
-However, keep in mind:
-=======
 **Note**:
->>>>>>> f3f1432fbc6b865564881f5687a3f8d8f687ff6e
 
 - To avoid mistakenly leaving text as untranslated, it can help to introduce the string sooner rather than later.
 - The naming of the string key should ideally be generalized enough to not be tightly coupled with the exact text, which can improve resilience to changes in copy.

--- a/_articles/appdev-i18n.md
+++ b/_articles/appdev-i18n.md
@@ -1,7 +1,7 @@
 ---
 title: "Translation process"
 layout: article
-description: "Process and guidelines for localization and string translation"
+description: "Process and guidelines for localization and string translation (i18n)"
 category: AppDev
 ---
 

--- a/_articles/appdev-i18n.md
+++ b/_articles/appdev-i18n.md
@@ -43,9 +43,9 @@ As new screens are added or existing views are updated, the set of localized str
 
 ### When should strings be added?
 
-Page copy will often change through the process of design iteration and by feedback from others on the team. It is up to the developer's discretion when to add strings to `config/locales`, as opposed to using temporary text in an in-progress implementation.
+During the design process, the page copy may often change through iteration and feedback from the team and/or directly from the public. UX Team members will include layouts that display English, French and Spanish translations prior to handing off for Engineering to build. You can read more about that process here:  
 
-However, keep in mind:
+NOTE:
 
 - To avoid mistakenly leaving text as untranslated, it can help to introduce the string sooner rather than later.
 - The naming of the string key should ideally be generalized enough to not be tightly coupled with the exact text, which can improve resilience to changes in copy.
@@ -61,12 +61,8 @@ You can also take advantage of some automated tooling to assist in this process:
 - Running `i18n-tasks add-missing` will generate placeholder values for all missing keys.
   - [See documentation for "`i18n-tasks add-missing`"](https://github.com/glebm/i18n-tasks#add-missing-keys)
 
-### How to translate strings?
+### How to request translations
 
 As mentioned earlier in this guide, the same YAML structure should exist for all supported locales, including the translated text values. Even if you are not a native speaker of the language, you should plan to include a translated value.
 
-This can be done by…
-
-1. Reaching out to colleagues within TTS who are native speakers of the language
-2. Or, making a best effort at a translation using a service like [Google Translate](https://translate.google.com/)
-3. Or, using the available professional translation services with whom Login.gov contracts. Contact Amber Van Amburg on Slack for more information.
+You can find specific guidance on how to request translations in the [Login.gov guidance document](https://docs.google.com/document/d/16RVO4Gr1bBTt8RV14Jsi1U77lKCBWRagowZbjdsXQ0w/edit).

--- a/_articles/saml.md
+++ b/_articles/saml.md
@@ -40,3 +40,38 @@ SamlIdp::AssertionBuilder#raw
 ## Testing with SAML-sinatra
 
 The SAML Sample app receives encrypted responses by default, but there is now an option to skip the encryption if desired so the response XML can be inspected in the browser tools listed above.
+
+## Invalid Signature
+
+If, when logging in to the SAML Sinatra sample app, you get an error saying:
+
+> Authentication Error! <br/>
+> Invalid Signature on SAML Response.
+
+This is usually caused by a mismatch between the IdP certificate used to sign the response, and the recorded signature of the certificate which is saved in the environment variable `idp_cert_fingerprint` (either in config/application.yml, or the environment variables in the deployed environment).
+
+To fix this, grab the certificate from the response, e.g.,
+
+```
+<KeyInfo 
+    xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <ds:X509Data>
+        <ds:X509Certificate>
+        MII/KeepCopyingButBreakItUpInto64CharacterLinesWhenYouSaveItHere...TheLastLineMayNotBeExactly64CharactersAndThatsOK=
+        </ds:X509Certificate>
+    </ds:X509Data>
+</KeyInfo>
+```
+edit it to look like a normal certificate (or find the orig), e.g., 
+```
+-----BEGIN CERTIFICATE-----
+MII/KeepCopyingButBreakItUpInto64CharacterLinesWhenYouSaveItHere
+...
+TheLastLineMayNotBeExactly64CharactersAndThatsOK=
+-----END CERTIFICATE-----
+```
+and finally calculate the fingerprint:
+```
+$ openssl x509 -noout -fingerprint -sha1 -inform pem -in file.crt
+SHA1 Fingerprint=AB:CD:EF:12:34:56:78:90:A1:B2:C3:D4:E5:F6:1A:2B:3C:4D:5E:6F
+```


### PR DESCRIPTION
This pull request updates the translation guidance for secure.login.gov and login.gov. It helps to make translations easier and more accurate for everyone on the team to be able to make translations if they need to.