### PR TITLE
Fix table of contents rendering on smaller viewports

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="grid-row grid-gap">
-  <aside class="grid-col-3">
+  <aside class="tablet:grid-col-3">
     <nav>
       {% assign h_max = page.toc_h_max | default: 3 %}
       {% include toc.html
@@ -16,7 +16,7 @@ layout: default
     </nav>
   </aside>
 
-  <div class="grid-col-8">
+  <div class="tablet:grid-col-8">
     <div class="usa-prose" role="main">
       <h1> {{ page.title }} </h1>
       {{ content | markdownify }}


### PR DESCRIPTION
Yay for USWDS

| Before | After |
| --- | ---- | 
| <img width="304" alt="Screen Shot 2021-02-16 at 9 29 41 AM" src="https://user-images.githubusercontent.com/458784/108099648-c118b200-7039-11eb-9076-0da67b988d29.png"> | <img width="304" alt="Screen Shot 2021-02-16 at 9 29 59 AM" src="https://user-images.githubusercontent.com/458784/108099661-c4ac3900-7039-11eb-9e33-96948309a08d.png"> |


