### PR TITLE
Update Virtual Machine guidance to link to IDP-specific instructions

### DIFF
--- a/_articles/windows-virtual-machine.md
+++ b/_articles/windows-virtual-machine.md
@@ -44,7 +44,7 @@ category: "AppDev"
 
 ## Configuring applications for local development
 
-In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses. Typically, this occurs by passing the host as an environment variable (e.g. `HOST=10.0.2.2 make run`).
+In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses. Typically, this can be done by passing the host as an environment variable (e.g. `HOST=10.0.2.2 make run`).
 
 For the IDP, see: ["Testing on a mobile device or in a virtual machine"](https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine)
 

--- a/_articles/windows-virtual-machine.md
+++ b/_articles/windows-virtual-machine.md
@@ -42,22 +42,11 @@ category: "AppDev"
       </div>
     </div>
 
-## Configure the IDP for local development
+## Configuring applications for local development
 
-Windows does not resolve `localhost`, it uses the IP address `10.0.2.2` instead,
-so we configure the IDP to use that name instead:
+In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses.
 
-1. Open `config/application.yml` in the [identity-idp](https://github.com/18f/identity-idp) repo
-
-2. Change the `domain_name` key to `10.0.2.2:3000`
-
-    ```
-    -  domain_name: localhost:3000
-    +  domain_name: 10.0.2.2:3000
-    ```
-
-3. Restart rails
-4. In your virtual machine, open IE and browse to <http://10.0.2.2:3000/>
+For the IDP, see: ["Testing on a mobile device or in a virtual machine"](https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine)
 
 ## Set up JAWS Screen Reader
 

--- a/_articles/windows-virtual-machine.md
+++ b/_articles/windows-virtual-machine.md
@@ -44,7 +44,7 @@ category: "AppDev"
 
 ## Configuring applications for local development
 
-In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses.
+In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses. Typically, this occurs by passing the host as an environment variable (e.g. `HOST=10.0.2.2 make run`).
 
 For the IDP, see: ["Testing on a mobile device or in a virtual machine"](https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine)
 


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4708#discussion_r582140342

**Why**:

- So content isn't duplicated between the handbook and IDP README, and instead exists as up-to-date in a single canonical location
- To apply guidance for all applications, not just IDP (e.g. sample apps)

**Live Preview:** https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.app.cloud.gov/preview/18f/identity-handbook/aduth-vm-idp-config/articles/windows-virtual-machine.html