### PR TITLE
Add OpenSSL recipes for converting pfx (pkcs12) to PEM

### DIFF
--- a/_articles/openssl-recipes.md
+++ b/_articles/openssl-recipes.md
@@ -173,7 +173,8 @@ openssl pkcs7 -print_certs \
 ## Convert PKCS12 (`.pfx`) to PEM
 
 PFX contains a public-private key pair. It may be protected by a password, and if so, the commands
-below will prompt for the password on stdin.
+below will prompt for the password on stdin. Is the password from AAMVA and OpenSSL isn't accepting it?
+See notes about [Password Encoding from AAMVA](#password-encoding-from-aamva) below.
 
 For these examples, we'll read from `$pfx_path` and export to `$private_pem` and `$public_pem`.
 

--- a/_articles/openssl-recipes.md
+++ b/_articles/openssl-recipes.md
@@ -181,7 +181,7 @@ For these examples, we'll read from `$pfx_path` and export to `$private_pem` and
 ```bash
 pfx_path="/in/some.pfx"
 private_pem="/out/private.pem"
-public_pem="/out/private.pem"
+public_pem="/out/public.pem"
 ```
 
 1. Export the private key

--- a/_articles/openssl-recipes.md
+++ b/_articles/openssl-recipes.md
@@ -217,7 +217,7 @@ File.read('password.txt')
 => "\xFF\xFE...."
 ```
 
-A few ways to convert the password so that OpensSSL accepted it:
+A few ways to convert the password so that OpenSSL accepted it:
 
 * TextEdit on macOS
 


### PR DESCRIPTION
I hope that in 3 years these just work so nobody has to blindly futz with OpenSSL