### PR TITLE
Deprecate lambda jobs article

### DIFF
--- a/_articles/appdev-lambda-jobs.md
+++ b/_articles/appdev-lambda-jobs.md
@@ -3,7 +3,18 @@ title: "Background Jobs: Lambda"
 description: "Overview of and launch checklist for our async Lambda workers"
 layout: article
 category: "AppDev"
+deprecated: true
 ---
+
+<div class="usa-alert usa-alert--info">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text" markdown="1">
+**Note**: This article is deprecated, we have removed the code for this
+approach in favor of a [Ruby Workers]({% link _articles/appdev-ruby-worker-jobs.md %}) approach, but are
+leaving this article up as a reference.
+    </p>
+  </div>
+</div>
 
 ## Overview
 

--- a/_includes/articles_category.md
+++ b/_includes/articles_category.md
@@ -17,6 +17,9 @@ Order articles by custom sorting first
 {%   for article in sorted_articles %}
 {%     if file == article.path and article.category == include.category %}
  - [{{article.title}}]({% include article_url.txt article=article %})
+   {%- if article.deprecated -%}
+     {: .deprecated-link} (deprecated)
+   {%- endif -%}
    {% if article.description %}<br/>{{ article.description }}{% endif %}
 {%     endif %}
 {%   endfor %}
@@ -29,6 +32,9 @@ Remaining articles (get sorted alphabetically)
 {%   if article.category == include.category %}
 {%     unless include.custom_order contains article.path %}
  - [{{article.title}}]({% include article_url.txt article=article %})
+   {%- if article.deprecated -%}
+     {: .deprecated-link} (deprecated)
+   {%- endif -%}
    {% if article.description %}<br/>{{ article.description }}{% endif %}
 {%     endunless %}
 {%   endif %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -18,7 +18,12 @@ layout: default
 
   <div class="tablet:grid-col-8">
     <div class="usa-prose" role="main">
-      <h1> {{ page.title }} </h1>
+      <h1>
+        {{ page.title }}
+        {% if page.deprecated %}
+          <small>(Deprecated)</small>
+        {% endif %}
+      </h1>
       {{ content | markdownify }}
     </div>
   </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -34,3 +34,7 @@
     }
   }
 }
+
+.deprecated-link {
+  color: gray;
+}


### PR DESCRIPTION
I don't know what our approach is for old articles, I figured this one was kind of useful as a reference so I opted to deprecated it rather than direct delete? I know we linked to it from some previous SCR docs

So I created a new concept of deprecating an article which adds:

| item | screenshot |
| --- | --- |
| grayed out link and deprecation note on homepage | <img width="485" alt="Screen Shot 2021-04-22 at 9 27 43 AM" src="https://user-images.githubusercontent.com/458784/115750907-83901800-a34d-11eb-9d96-6b28e9644a6c.png"> |
| deprecated title on article page | <img width="701" alt="Screen Shot 2021-04-22 at 9 27 35 AM" src="https://user-images.githubusercontent.com/458784/115750919-8559db80-a34d-11eb-972f-f2e2c1708f97.png"> |

