### PR TITLE
Update deploy docs

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -238,8 +238,8 @@ the bug in staging, where it won't affect end users.
 To quickly remove new servers and leave old servers up:
 
 ```bash
-aws-vault exec prod-power -- ./bin/scale-out-old-instances prod idp
-aws-vault exec prod-power -- ./bin/scale-out-old-instances prod idpxtra
+aws-vault exec prod-power -- ./bin/scale-in-new-instances prod idp
+aws-vault exec prod-power -- ./bin/scale-in-new-instances prod idpxtra
 ```
 
 ##### Steps to roll back

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -192,7 +192,7 @@ Scheduled for every other Thursday
 1. **PRODUCTION ONLY**: This step is required in production
 
     Production boxes need to be manually marked as safe to remove (one more step that helps us prevent ourselves from accidentally taking production down)
-    ```
+    ```bash
     aws-vault exec prod-power -- ./bin/scale-in-old-instances prod idp
     aws-vault exec prod-power -- ./bin/scale-in-old-instances prod idpxtra
     ```
@@ -231,6 +231,15 @@ Some criteria for rolling back:
 If any of these are "yes", roll back. See more criteria at <https://outage.party/>.
 Staging is a pretty good match for production, so you should be able to fix and verify
 the bug in staging, where it won't affect end users.
+
+##### Scaling Out
+
+To quickly remove new servers and leave old servers up:
+
+```bash
+aws-vault exec prod-power -- ./bin/scale-out-old-instances prod idp
+aws-vault exec prod-power -- ./bin/scale-out-old-instances prod idpxtra
+```
 
 ##### Steps to roll back
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -159,17 +159,16 @@ Scheduled for every other Thursday
 1. In the `identity-devops` repo:
    ```bash
    cd identity-devops
-   aws-vault exec prod-power -- /bin/zsh
    ```
 1. Recycle the IDP instances to get the new code, it automatically creates a new migration instance first.
    ```bash
-   ./bin/asg-recycle prod idp
+   aws-vault exec prod-power -- ./bin/asg-recycle prod idp
    ```
 
    1. Follow the progress of the migrations, ensure that they are working properly
    ```bash
    # may need to wait a few seconds after the recycle
-   ./bin/ssm-instance --newest asg-prod-migration
+   aws-vault exec prod-power -- ./bin/ssm-instance --newest asg-prod-migration
    ```
    On the remote box
    ```bash
@@ -183,7 +182,7 @@ Scheduled for every other Thursday
    1. Follow the progress of the IDP hosts spinning up
 
       ```bash
-      ./bin/ls-servers -e prod -r idp # check the load balance pool health
+      aws-vault exec prod-power -- ./bin/ls-servers -e prod -r idp # check the load balance pool health
       ```
 
     1. Manual Inspection
@@ -194,8 +193,8 @@ Scheduled for every other Thursday
 
     Production boxes need to be manually marked as safe to remove (one more step that helps us prevent ourselves from accidentally taking production down)
     ```
-    ./bin/scale-in-old-instances prod idp
-    ./bin/scale-in-old-instances prod idpxtra
+    aws-vault exec prod-power -- ./bin/scale-in-old-instances prod idp
+    aws-vault exec prod-power -- ./bin/scale-in-old-instances prod idpxtra
     ```
 
 1. Set a timer for one hour, then check NewRelic again for errors.


### PR DESCRIPTION
- Add `aws-vault` prefix to every command so it's less error-prone to copy-paste individual lines
- Add more rollback instructions
- Add notes for `--skip-migration` for recycle deploys