### PR TITLE
Update configuration to use NPM instead of Yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,18 +20,18 @@ jobs:
             - gem-cache-v1
       - restore_cache:
           keys:
-            - yarn-packages-v1-{{ checksum "yarn.lock" }}
-            - yarn-packages-v1-
+            - npm-packages-v1-{{ checksum "package-lock.json" }}
+            - npm-packages-v1-
       - run: bundle install --path vendor/bundle
-      - run: yarn install
+      - run: npm install
       - save_cache:
           key: gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - save_cache:
-          key: yarn-packages-v1-{{ checksum "yarn.lock" }}
+          key: npm-packages-v1-{{ checksum "package-lock.json" }}
           paths:
-            - ~/.cache/yarn
+            - ~/.npm
       - run:
           name: Run markdown source spec (catches things that might break the build)
           command: bundle exec rspec `pwd`/spec/markdown_spec.rb

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ plugins:
 
 exclude:
   - CONTRIBUTING.md
-  - yarn.lock
+  - package-lock.json
   - Makefile
   - package.json
   - Gemfile


### PR DESCRIPTION
**Why**: Jekyll and CircleCI configurations assume a Yarn lockfile which doesn't exist. It (as well as a package-lock.json) had existed prior to #2. There should be only one. Since there's already an NPM lockfile, use it for caching, and exclude from Jekyll build.