### PR TITLE
Rename build workflow to omit "deploy" mention

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
             - "_site/*"
 workflows:
   version: 2
-  # run on pull requests and after merges
-  build_and_deploy:
+  build:
     jobs:
       - build


### PR DESCRIPTION
**Why**: There is no deployment as part of CircleCI. This happens in Federalist. This was a remnant from the old private version of the handbook, which included a deployment step.