### PR TITLE
Pepper the Emergency Contact List a few places

### DIFF
--- a/_articles/appdev-oncall-guide.md
+++ b/_articles/appdev-oncall-guide.md
@@ -26,6 +26,10 @@ Rotations:
 1. [Primary Oncall ("End-User Primary")](https://login-gov.app.opsgenie.com/settings/schedule/detail/142b8527-8ef6-4d9d-b81e-24b45d0499ba)
 2. [Secondary Oncall ("End-User Secondary")](https://login-gov.app.opsgenie.com/settings/schedule/detail/1271f41d-aa0c-4a3e-86aa-23162ab5fc9d)
 
+## Emergency Contacts
+
+For login.gov and vendor emergency contact information see [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts)
+
 ## Handoff
 
 The AppDev Rotation hands off every **Monday at 12pm Eastern (9am Pacific)**.

--- a/_articles/incident-response-checklist.md
+++ b/_articles/incident-response-checklist.md
@@ -14,7 +14,7 @@ This is a quick checklist for any incident (security, privacy, outage, degraded 
 * Situation Lead (SL) assigned - Responsible for ensuring all following steps are completed
 * Incident declared in [#login-situation](https://gsa-tts.slack.com/archives/C5QUGUANN)
 * SL and team assemble in War Room (*Posted at top of #login-situation channel)
-* Slack or OpsGenie used to alert additional responders
+* Slack or OpsGenie used to alert additional responders  (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
 * Roles assigned 
   * **Technical lead (TL)**: Leads technical investigation and mitigation
   * **Comms lead (CL)**: Coordinates communication outside of #login-situation, within GSA, and if needed, with partners and the public


### PR DESCRIPTION
https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts exists and should probably be linked in a few spots.