### PR TITLE
Add notes to incident guide

### DIFF
--- a/_articles/appdev-lambda-jobs.md
+++ b/_articles/appdev-lambda-jobs.md
@@ -6,15 +6,13 @@ category: "AppDev"
 deprecated: true
 ---
 
-<div class="usa-alert usa-alert--info">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text" markdown="1">
+{%- capture alert_content -%}
 **Note**: This article is deprecated, we have removed the code for this
 approach in favor of a [Ruby Workers]({% link _articles/appdev-ruby-worker-jobs.md %}) approach, but are
 leaving this article up as a reference.
-    </p>
-  </div>
-</div>
+{%- endcapture -%}
+
+{% include alert.html content=alert_content %}
 
 ## Overview
 

--- a/_articles/appdev-smoketest-debugging.md
+++ b/_articles/appdev-smoketest-debugging.md
@@ -40,10 +40,10 @@ See the IDP's README for info on [how to set up and run the smoke tests][idpsmok
 ### Failed to Find Email that Matched
 
 ```
-     Failure/Error: raise "failed to find email that matched #{regex}"
+Failure/Error: raise "failed to find email that matched #{regex}"
 
-     RuntimeError:
-       failed to find email that matched (?-mix:(?<link>https?:.+reset_password_token=[\w\-]+))
+RuntimeError:
+   failed to find email that matched (?-mix:(?<link>https?:.+reset_password_token=[\w\-]+))
 ```
 
 This error occurs when we are expecting to find an email matching a given, regex.
@@ -68,16 +68,14 @@ signing in to login.gov. Occasionally those sites go down, and so the smoke test
 that use those sites fail.
 
 
-<div class="usa-alert usa-alert--info usa-alert--no-icon" >
-  <div class="usa-alert__body">
-    <p class="usa-alert__text" markdown="1">
-      **Note**: To have more control over these smoke tests, ideally we would
-      host our own sample apps in production. Unfortunately, hosting an app
-      in production requires including it in our ATO boundary, so to mimimize
-      headaches, we choose to rely on partners like this.
-    </p>
-  </div>
-</div>
+{%- capture alert_content -%}
+**Note**: To have more control over these smoke tests, ideally we would
+host our own sample apps in production. Unfortunately, hosting an app
+in production requires including it in our ATO boundary, so to mimimize
+headaches, we choose to rely on partners like this.
+{%- endcapture -%}
+
+{% include alert.html content=alert_content %}
 
 **What to do**: Check the partner site manually, if it's down, try signing
 in to login.gov through another partner site to make sure things are still up.

--- a/_articles/deploying-sp-to-prod.md
+++ b/_articles/deploying-sp-to-prod.md
@@ -7,13 +7,12 @@ category: Partnerships
 
 Here is a list of items that need to be completed to deploy the configuration for a partner SP (Service Provider) to Production.
 
-<div class="usa-alert usa-alert--info">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text" markdown="1">
-      **Note to AppDev**: You should probably work with the Partnership team to ensure that steps 1-4 are complete.
-    </p>
-  </div>
-</div>
+
+{%- capture alert_content -%}
+**Note to AppDev**: You should probably work with the Partnership team to ensure that steps 1-4 are complete.
+{%- endcapture %}
+
+{% include alert.html content=alert_content %}
 
 1. Ensure that the IAA is signed for the hubspot deal. You should see a "IAA Approved" with an "IAA Number" on the deal. Please contact Silke if unsure. If the IAA is not approved, then let the partner know that the app cannot be deployed to production until the IAA is signed.
 

--- a/_articles/incident-response-checklist.md
+++ b/_articles/incident-response-checklist.md
@@ -11,14 +11,14 @@ This is a quick checklist for any incident (security, privacy, outage, degraded 
 
 ## Initiate
 
-* Situation Lead (SL) assigned - Responsible for ensuring all following steps are completed
-* Incident declared in [#login-situation](https://gsa-tts.slack.com/archives/C5QUGUANN)
-* SL and team assemble in War Room (*Posted at top of #login-situation channel)
-* Slack or OpsGenie used to alert additional responders  (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
-* Roles assigned 
+* Roles assigned
+  * **Situation Lead (SL)**: - Responsible for ensuring all following steps are completed
   * **Technical lead (TL)**: Leads technical investigation and mitigation
   * **Comms lead (CL)**: Coordinates communication outside of #login-situation, within GSA, and if needed, with partners and the public
-  * **Scribe (S)**: Relays information discussed in war room (hangout) to #login-situation and aids SL in recording incident
+  * **Scribe (S)**: Relays information discussed in war room (hangout) to #login-situation and aids Situation Lead in recording incident
+* Incident declared in [#login-situation](https://gsa-tts.slack.com/archives/C5QUGUANN)
+* Situation Lead and team assemble in War Room (*Posted at top of #login-situation channel)
+* Slack or OpsGenie used to alert additional responders  (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
 * Issue created as official record for incident: [Incident Template](https://github.com/18F/identity-security-private/issues/new?template=incidents.md)
 * Email sent to GSA Incident Response <gsa-ir@gsa.gov> AND IT Service Desk <itservicedesk@gsa.gov> (or GSA IT Helpline called) **within 1 hour** of start of incident ([Alternate contact methods](https://insite.gsa.gov/employee-resources/information-technology))
 
@@ -42,16 +42,17 @@ This is a quick checklist for any incident (security, privacy, outage, degraded 
 
 Loop through per-role items until remediation is complete.
 
-By Role:
+**By Role**
 * Situation Lead
-  * Wellbeing of group monitored, including SL (Tired and stressed humans make poor decisions)
+  * Wellbeing of group monitored, including self (Tired and stressed humans make poor decisions)
   * Rotations of all roles planned and performed to prevent any responder spending more than 3 hours in role
 * Technical Lead
-  * Lead technical response till issue is remediated OR role is handed off
-* Comms Lead:
+  * Lead technical response till issue is remediated
+  * **OR** role is handed off
+* Comms Lead
   * Regular updates to interested parties provided
   * StatusPage updated as status changes
-* Scribe:
+* Scribe
   * Ensure a full record is being maintained
 
 

--- a/_articles/incident-response-checklist.md
+++ b/_articles/incident-response-checklist.md
@@ -18,7 +18,7 @@ This is a quick checklist for any incident (security, privacy, outage, degraded 
   * **Scribe (S)**: Relays information discussed in war room (hangout) to #login-situation and aids Situation Lead in recording incident
 * Incident declared in [#login-situation](https://gsa-tts.slack.com/archives/C5QUGUANN)
 * Situation Lead and team assemble in War Room (*Posted at top of #login-situation channel)
-* Slack or OpsGenie used to alert additional responders  (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
+* Slack or OpsGenie used to alert additional responders (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
 * Issue created as official record for incident: [Incident Template](https://github.com/18F/identity-security-private/issues/new?template=incidents.md)
 * Email sent to GSA Incident Response <gsa-ir@gsa.gov> AND IT Service Desk <itservicedesk@gsa.gov> (or GSA IT Helpline called) **within 1 hour** of start of incident ([Alternate contact methods](https://insite.gsa.gov/employee-resources/information-technology))
 

--- a/_articles/secops-incident-response-guide.md
+++ b/_articles/secops-incident-response-guide.md
@@ -2,7 +2,7 @@
 title: "Incident Response Guide"
 description: "Security Incident Response Guide"
 layout: article
-category: "Team"
+category: "Security"
 ---
 
 ## Introduction

--- a/_articles/secops-incident-response-guide.md
+++ b/_articles/secops-incident-response-guide.md
@@ -9,7 +9,13 @@ category: "Team"
 
 This document outlines login.gov’s process for responding to incidents. It outlines roles and responsibilities during and after incidents, and it lays out the steps we’ll take to resolve them.
 
-See the [Incident Response Checklist]({% link _articles/incident-response-checklist.md %}) for a quick reference.
+{%- capture alert_content -%}
+This is the full explicit document!
+<br />
+In a situation? Check the [Incident Response Checklist]({% link _articles/incident-response-checklist.md %}) for a quick reference.
+{%- endcapture -%}
+
+{% include alert.html content=alert_content %}
 
 The formal version from the FedRAMP Agency ATO package can be found here [Login.gov Incident Response Plan](https://drive.google.com/open?id=1Em3F3oZF_SRuuRLqwr6-pwlE4iNmT2ix)
 

--- a/_articles/windows-virtual-machine.md
+++ b/_articles/windows-virtual-machine.md
@@ -34,13 +34,11 @@ category: "AppDev"
 
 8. Log in to the virtual machine
 
-    <div class="usa-alert usa-alert--info">
-      <div class="usa-alert__body">
-        <p class="usa-alert__text" markdown="1">
-          The password is `Passw0rd!`
-        </p>
-      </div>
-    </div>
+   {%- capture alert_content -%}
+   The password is `Passw0rd!`
+   {%- endcapture -%}
+
+   {% include alert.html content=alert_content %}
 
 ## Configuring applications for local development
 

--- a/_includes/alert.html
+++ b/_includes/alert.html
@@ -1,0 +1,12 @@
+{% comment %}
+include
+- content
+- alert_class (optional)
+{% endcomment %}
+<div class="usa-alert {{ include.alert_class | default: 'usa-alert--info' }}">
+  <div class="usa-alert__body">
+    <p class="usa-alert__text" markdown="1">
+      {{ include.content }}
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
**Main Change**: Highlighting the note from the long incident response checklist as a block

<img width="585" alt="Screen Shot 2021-05-27 at 2 58 54 PM" src="https://user-images.githubusercontent.com/458784/119902442-13e8ec00-befc-11eb-9287-9d99fa504a7d.png">

**Other Changes**:
- Factor out a partial for alerts
- Small cleanups to the short incident checklist
- Move the secops (full guide) into its own category so it's easier to find the short checklist at the top of the page