### PR TITLE
Fix search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,7 +84,7 @@
       var sjs = SimpleJekyllSearch({
         searchInput: document.getElementById('search-input'),
         resultsContainer: document.getElementById('search-results'),
-        json: '/search.json',
+        json: '{{ site.baseurl }}/search.json',
         noResultsText: '<li class="no-results">No results were found.</li>'
       });
     </script>

--- a/search.json
+++ b/search.json
@@ -4,10 +4,10 @@ layout: null
 [
   {% for article in site.articles %}
     {
-      "title"    : "{{ article.title | escape }}",
+      "title"    : {{ article.title | jsonify }},
       "desc"     : {{ article.description | jsonify }},
-      "category" : "{{ article.category }}",
-      "tags"     : "{{ article.tags | join: ', ' }}",
+      "category" : {{ article.category | jsonify }},
+      "tags"     : {{ article.tags | join: ', ' | jsonify }},
       "url"      : "{{ site.baseurl }}{{ article.url }}",
       "date"     : "{{ article.date }}",
       "content"  : {{ article.content | strip_html | jsonify}}

--- a/search.json
+++ b/search.json
@@ -5,6 +5,7 @@ layout: null
   {% for article in site.articles %}
     {
       "title"    : "{{ article.title | escape }}",
+      "desc"     : {{ article.description | jsonify }},
       "category" : "{{ article.category }}",
       "tags"     : "{{ article.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ article.url }}",


### PR DESCRIPTION
We were missing a `desc` attribute in `search.json` so it wasn't being interpolated as a title attribute correctly

| before | after |
| --- | --- |
| <img width="359" alt="Screen Shot 2021-07-08 at 4 08 59 PM" src="https://user-images.githubusercontent.com/458784/125001246-0d738700-e007-11eb-95ec-48a7a99f5368.png">  | <img width="359" alt="Screen Shot 2021-07-08 at 4 08 10 PM" src="https://user-images.githubusercontent.com/458784/125001250-0ea4b400-e007-11eb-9df4-a51a3795d074.png"> |
