### PR TITLE
Add instructions to the deploy manager guide to test proofing in staging

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -66,26 +66,24 @@ Scheduled for every **Tuesday**
 
 #### Test the proofing flow in staging
 
-Since testing proofing requires an actual person's PII, we don't have a good mechanism for automated testing of the live proofing flow.
-As a work-around, we test by proofing and staging, then cutting a release from the code deployed to staging.
+Since identity proofing requires an actual person's PII, we don't have a good mechanism for automated testing of the live proofing flow.
+As a work-around, we test by proofing in staging, then cutting a release from the code deployed to staging.
 
 Before cutting a release, make sure to test in staging.
 If there are specific commits that need to be deployed, make sure to recycle staging first to include those commits.
 
-Once you've run through a proof in staging, the next step is to cut a release from the code that is deployed to staging.
+Once you've run through proofing in staging, the next step is to cut a release from the code that is deployed to staging.
 
 #### Cut a release branch
 
-The release branch should be cut from latest and it should be the date of the production release (ex `stages/rc-2020-06-17`):
+The release branch should be cut from code tested in staging and it should be the date of the production release (ex `stages/rc-2020-06-17`):
 
 ```bash
 cd identity-$REPO
-git fetch && git checkout <staging sha>
+git fetch && git checkout $(curl --silent https://idp.staging.login.gov/api/deploy.json | jq -r .git_sha)
 git checkout -b stages/rc-2020-06-17 # CHANGE THIS DATE
 git push -u origin HEAD
 ```
-
-To get the staging sha, look for the sha of the code that was tested in staging [here](https://idp.staging.login.gov/api/deploy.json).
 
 #### Create pull request
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -64,16 +64,28 @@ Note: it is a good idea to make sure you have the latest pulled down from identi
 ### Pre-deploy
 Scheduled for every **Tuesday**
 
+#### Test the proofing flow in staging
+
+Since testing proofing requires an actual person's PII, we don't have a good mechanism for automated testing of the live proofing flow.
+As a work-around, we test by proofing and staging, then cutting a release from the code deployed to staging.
+
+Before cutting a release, make sure to test in staging.
+If there are specific commits that need to be deployed, make sure to recycle staging first to include those commits.
+
+Once you've run through a proof in staging, the next step is to cut a release from the code that is deployed to staging.
+
 #### Cut a release branch
 
 The release branch should be cut from latest and it should be the date of the production release (ex `stages/rc-2020-06-17`):
 
 ```bash
 cd identity-$REPO
-git checkout main && git pull
+git fetch && git checkout <staging sha>
 git checkout -b stages/rc-2020-06-17 # CHANGE THIS DATE
 git push -u origin HEAD
 ```
+
+To get the staging sha, look for the sha of the code that was tested in staging [here](https://idp.staging.login.gov/api/deploy.json).
 
 #### Create pull request
 


### PR DESCRIPTION
**Why**: Because, unfortunately, the live proofing flow is not covered by automated testing