### PR TITLE
Slack channel naming conventions

### DIFF
--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -8,6 +8,12 @@ toc_h_max: 4
 
 We use Slack extensively!
 
+## Channel naming conventions
+
+- All channels begin with `#login-`
+- All channels with external collaborators start with `#login-partners-`
+- Team channels look like `#login-team-<name>`
+
 ## Groups
 
 Use these to ping a large group of people, without having to **@here** or **@channel** a room full of the wrong people.

--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -12,7 +12,7 @@ We use Slack extensively!
 
 - All channels begin with `#login-`
 - All channels with external collaborators start with `#login-partners-`
-- Team channels look like `#login-team-<name>`
+- Sprint team channels look like `#login-team-<name>`
 
 ## Groups
 


### PR DESCRIPTION
First, I'd like to get consensus on some naming conventions for our channels.  After we seem :+1: I will embark on a journey to rename channels that do not comply.

[Here is a GSheet with an export of our public channels.](https://docs.google.com/spreadsheets/d/1EmV8arSvs0HARB95rTUGVgUtiAdGYzvQcZbrItmrrV4/edit?ts=60eca39a#gid=0)

Can you think of any more naming conventions we should have?