### PR TITLE
Add environments stub page

### DIFF
--- a/_articles/sandboxes-and-staging-environments.md
+++ b/_articles/sandboxes-and-staging-environments.md
@@ -1,0 +1,7 @@
+---
+title: Environment Descriptions
+description: Listing of environments and the differences between them
+layout: article
+category: AppDev
+redirect_to: https://docs.google.com/document/d/1N_R53Cjk-L7sHpS0G65an1_l4s8B9KRzgFRU27-WAfs/
+---

--- a/_articles/sandboxes-and-staging-environments.md
+++ b/_articles/sandboxes-and-staging-environments.md
@@ -1,6 +1,6 @@
 ---
 title: Environment Descriptions
-description: Listing of environments and the differences between them
+description: Listing of environments and the differences between them, like prod, pt, dm, int or dev
 layout: article
 category: AppDev
 redirect_to: https://docs.google.com/document/d/1N_R53Cjk-L7sHpS0G65an1_l4s8B9KRzgFRU27-WAfs/


### PR DESCRIPTION
**Why**: So that we can have a reference for which environments exist and the differences between them.

Redirects to an internal Google Doc.