### PR TITLE
Update reporting dashboard image caption

### DIFF
--- a/_articles/reporting-dashboard-architecture.md
+++ b/_articles/reporting-dashboard-architecture.md
@@ -11,7 +11,7 @@ We serve a dashboard at [data.login.gov][data-login-gov] with metrics that are s
 share with the public
 
 ![architecture diagram of reporting dashboard]({{site.baseurl}}/images/reporting-dashboard-diagram.png)
-(to update this diagram, edit the [Async Architecture][figma] file in Figma and re-export it)
+(to update this diagram, edit the [data.login.gov report architecture][figma] file in Figma and re-export it)
 
 [figma]: https://www.figma.com/file/DGQZwlRbJtEZGJH0t2iMvD/data.login.gov-report-architecture
 


### PR DESCRIPTION
**Why**: Because it's inaccurate, and likely a copy-paste error from similar [Background Jobs article / image](https://handbook.login.gov/articles/appdev-proofing-ruby-worker-jobs.html).

See also: https://github.com/18F/identity-handbook/pull/158#discussion_r697110515