### PR TITLE
Add design system link styling

### DIFF
--- a/_plugins/content_typography.rb
+++ b/_plugins/content_typography.rb
@@ -1,0 +1,12 @@
+module Kramdown
+  module Parser
+    class Kramdown
+      prepend(Module.new do
+        def add_link(el, *args)
+          el.attr['class'] = [*el.attr['class'], 'usa-link'].join(' ') if el.type == :a
+          super(el, *args)
+        end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
**Why**: So that links are styled using the design system, instead of browser defaults.

An alternative can be to configure [the `$theme-global-link-styles` SASS variable](https://github.com/uswds/uswds/blob/019eda3109a9074923e60326a4aadb4c6b56d04a/src/stylesheets/global/_typography.scss#L17-L19). However, this applies to all links in the layout, which may have unexpected repercussions. Instead, extending Kramdown ensures that styles are only applied to parsed Markdown content.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/134355262-01ce423e-b0ba-4449-8e14-ea24771a48ce.png)|![image](https://user-images.githubusercontent.com/1779930/134355274-8e73c7fc-f33c-4b3f-91e7-2e03c2071f8e.png)

Kramdown monkey-patching reference: https://github.com/gettalong/kramdown/blob/0b0a9e0/lib/kramdown/parser/kramdown/link.rb#L37-L51