### PR TITLE
Remove needing to switch to /bin/bash

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -195,7 +195,6 @@ Scheduled for every Thursday
    ```
    On the remote box
    ```bash
-   /bin/bash # they start in a plain shell, you probably want bash
    sudo tail -f /var/log/cloud-init-output.log
    # OR
    sudo tail -f /var/log/syslog

--- a/_articles/appdev-troubleshooting-sandbox.md
+++ b/_articles/appdev-troubleshooting-sandbox.md
@@ -18,7 +18,6 @@ If a user accidentally uploads real PII to our sandbox environment, follow the s
     ```
 3. Once the SSM session is established, run the following commands to start a Rails console session:
     ```bash
-    /bin/bash
     cd /srv/idp/current
     sudo -uwebsrv ALLOW_CONSOLE_DB_WRITE_ACCESS=true bin/rails c
     ```


### PR DESCRIPTION
- Now that 18f/identity-devops#3865 and 18f/identity-devops#3859
  have merged, ssm-instance starts in a bash shell already