### PR TITLE
Update user queries

### DIFF
--- a/_articles/queries.md
+++ b/_articles/queries.md
@@ -15,6 +15,14 @@ For queries that take longer than the default timeout (2.5s), run the following 
 ActiveRecord::Base.connection.execute 'SET statement_timeout = 200000'
 ```
 
+## Total Registered
+
+Returns the number of users that created accounts (this includes users who may not have fully registered, see [Fully Registered Users](#fully-registered-users) for that query)
+
+```ruby
+User.count
+```
+
 ## Fully Registered Users
 
 Returns the number of fully registered users.

--- a/_articles/queries.md
+++ b/_articles/queries.md
@@ -23,6 +23,13 @@ Returns the number of users that created accounts (this includes users who may n
 User.count
 ```
 
+To approximate the count at a past point in time, substitute `date` below:
+
+```ruby
+date = Date.new(2021, 1, 1)
+User.where('created_at <= ?', date).count
+```
+
 ## Fully Registered Users
 
 Returns the number of fully registered users.
@@ -33,10 +40,24 @@ Returns the number of fully registered users.
 RegistrationLog.where.not(registered_at: nil).count
 ```
 
+To approximate the count at a past point in time, substitute `date` below:
+
+```ruby
+date = Date.new(2021, 1, 1)
+RegistrationLog.where('registered_at <= ?', date).count
+```
+
 ## IAL2 Users
 
 Returns the number of users with IAL2 credentials.
 
 ```ruby
 Profile.where(active: true).count
+```
+
+To approximate the count at a past point in time, substitute `date` below:
+
+```ruby
+date = Date.new(2021, 1, 1)
+Profile.where(active: true).where('activated_at < ?', date).count
 ```


### PR DESCRIPTION
- Adds a new "total accounts created" (slightly different from "fully registered IAL 1")
- Adds forms of queries that can be used to approximate historical values (account deletes may mess with all of those, which is why they are not exact)