### PR TITLE
Added team handles for Teams Grace and Katherine

### DIFF
--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -37,6 +37,8 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 - `@login-appdev-team` Group for application development teams
 - `@login_leads` login team leads
 - `@login-feds` Group for Login.gov federal FTE employees
+- `@login-grace` To tag Team Grace, one of the AppDev teams that works on the IdP
+- `@login-katherine` To tag Team Katherine, one of the AppDev teams that works on the IdP and the brochure site
 - `@github-admins-login` members of this group can edit [`identity-core`](https://github.com/orgs/18F/teams/identity-core) GitHub team membership
 
 ## Channels


### PR DESCRIPTION
Listing `@login-grace` and `@login-katherine` under [Team Handles](https://handbook.login.gov/articles/slack.html#team-handles)