### PR TITLE
Add dynamically loaded team page from GitHub

### DIFF
--- a/_articles/team.md
+++ b/_articles/team.md
@@ -1,0 +1,28 @@
+---
+title: Team Members
+description: The login.gov team roster
+layout: article
+category: Team
+---
+
+This page is dynamically generated from [identity-private/team.yml][team-yml]
+every time the handbook is deployed.
+
+[team-yml]: https://github.com/18F/identity-private/blob/main/team/team.yml
+
+<div id="error-container"></div>
+
+### Current Team Members
+
+<div id="team-container"></div>
+
+### Alumni
+
+<div id="alumni-container"></div>
+
+<script type="module">
+import { loadTeam } from '{{ "/assets/build/team.js" | prepend: site.baseurl }}';
+
+loadTeam();
+</script>
+

--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -1,6 +1,7 @@
-import { h, render, Fragment, ComponentChildren } from "preact";
+import { h, render, Fragment } from "preact";
 import Anchor from "anchor-js";
 import { loggedInUser, PrivateLoginLink } from "./private";
+import { Alert } from "./components/alert";
 
 interface AnalyticsEventAttribute {
   name: string;
@@ -190,23 +191,6 @@ function SidebarNavItem({ name }: { name: string }) {
     <li className="usa-sidenav__item">
       <a href={`#${urlify(name)}`}>{name}</a>
     </li>
-  );
-}
-
-function Alert({
-  heading,
-  children,
-}: {
-  heading?: string;
-  children: ComponentChildren;
-}) {
-  return (
-    <div className="usa-alert usa-alert--error">
-      <div className="usa-alert__body">
-        <h5 className="usa-alert__heading">{heading}</h5>
-        <div className="usa-alert__text">{children}</div>
-      </div>
-    </div>
   );
 }
 

--- a/assets/js/components/alert.tsx
+++ b/assets/js/components/alert.tsx
@@ -1,0 +1,18 @@
+import { h, ComponentChildren } from "preact";
+
+export function Alert({
+  heading,
+  children,
+}: {
+  heading?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <div className="usa-alert usa-alert--error">
+      <div className="usa-alert__body">
+        <h5 className="usa-alert__heading">{heading}</h5>
+        <div className="usa-alert__text">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/assets/js/setup.tsx
+++ b/assets/js/setup.tsx
@@ -28,6 +28,7 @@ export const loadPrivateEye = () => {
       "github.com/18f/identity-devops",
       "github.com/18f/identity-devops-private",
       "github.com/18f/identity-handbook-private",
+      "github.com/18f/identity-private",
       "github.com/18f/identity-idp-config",
       "gkey.gsa.gov",
       "gsa-tts.slack.com",

--- a/assets/js/team.tsx
+++ b/assets/js/team.tsx
@@ -1,0 +1,112 @@
+import { h, render, Fragment } from "preact";
+import { load as loadYAML } from "js-yaml";
+import { Alert } from "./components/alert";
+import { loggedInUser, PrivateLoginLink } from "./private";
+
+interface GithubFile {
+  content: string;
+  encoding: "base64" | string;
+}
+
+interface TeamMember {
+  name: string;
+  github: string;
+  subteam?: string;
+  responsibilities?: string;
+  email?: string | string[];
+  home_orgs?: string;
+  fed?: boolean;
+  aws?: string;
+}
+
+interface Alum {
+  name: string;
+  github: string;
+}
+
+interface TeamRoster {
+  team_members: TeamMember[];
+  alumni: TeamMember[];
+}
+
+function GithubLink({ username }: { username: string }) {
+  return <a href={`https://github.com/${username}`}>@{username}</a>;
+}
+
+function TeamMemberRoster({ members }: { members: TeamMember[] }) {
+  return (
+    <ul>
+      {members
+        .sort(({ name: aName }, { name: bName }) => aName.localeCompare(bName))
+        .map(({ name, github, email, subteam, responsibilities, fed, aws }) => (
+          <li>
+            <strong>{name}</strong> <GithubLink username={github} />
+            <br />
+            Email: {email}
+            <br />
+            Subteam: {subteam}
+            <br />
+            Responsibilities: {responsibilities}
+            <br />
+            Fed: {String(fed)}
+            <br />
+            {aws ? <>AWS: {aws}</> : undefined}
+          </li>
+        ))}
+    </ul>
+  );
+}
+
+function AlumRoster({ members }: { members: Alum[] }) {
+  return (
+    <ul>
+      {members
+        .sort(({ name: aName }, { name: bName }) => aName.localeCompare(bName))
+        .map(({ name, github }) => (
+          <li>
+            <strong>{name}</strong> <GithubLink username={github} />
+          </li>
+        ))}
+    </ul>
+  );
+}
+
+export function loadTeam() {
+  const jekyllBaseUrl = document.body.dataset.baseUrl as string;
+  const currentUser = loggedInUser();
+
+  if (currentUser) {
+    const teamContainer = document.getElementById(
+      "team-container"
+    ) as HTMLElement;
+    const alumniContainer = document.getElementById(
+      "alumni-container"
+    ) as HTMLElement;
+
+    window
+      .fetch(
+        "https://api.github.com/repos/18f/identity-private/contents/team/team.yml",
+        { headers: { Authorization: `token ${currentUser.token}` } }
+      )
+      .then((response) => response.json())
+      .then((json: GithubFile) => {
+        const { team_members: teamMembers, alumni } = loadYAML(
+          atob(json.content)
+        ) as TeamRoster;
+
+        render(<TeamMemberRoster members={teamMembers} />, teamContainer);
+        render(<AlumRoster members={alumni} />, alumniContainer);
+      });
+  } else {
+    const errorContainer = document.getElementById(
+      "error-container"
+    ) as HTMLElement;
+
+    render(
+      <Alert heading="Error loading team roster">
+        Team roster requires <PrivateLoginLink baseUrl={jekyllBaseUrl} />
+      </Alert>,
+      errorContainer
+    );
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
         "anchor-js": "^4.2.2",
         "htm": "^3.1.0",
         "identity-style-guide": "^6.3.0",
+        "js-yaml": "^4.1.0",
         "preact": "^10.6.6",
         "simple-jekyll-search": "^1.10.0"
       },
       "devDependencies": {
         "@18f/eslint-plugin-identity": "^2.0.0",
+        "@types/js-yaml": "^4.0.5",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "esbuild": "^0.14.27",
@@ -175,6 +177,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.10",
@@ -493,8 +501,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
       "version": "4.2.2",
@@ -2206,7 +2213,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3270,6 +3276,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.10",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
@@ -3465,8 +3477,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
       "version": "4.2.2",
@@ -4649,7 +4660,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
     "anchor-js": "^4.2.2",
     "htm": "^3.1.0",
     "identity-style-guide": "^6.3.0",
+    "js-yaml": "^4.1.0",
     "preact": "^10.6.6",
     "simple-jekyll-search": "^1.10.0"
   },
   "devDependencies": {
     "@18f/eslint-plugin-identity": "^2.0.0",
+    "@types/js-yaml": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "esbuild": "^0.14.27",


### PR DESCRIPTION
- We can drop this page from the old private GitHub now
- Working example of pulling private content for our team from GitHub. Next up: entirely private articles

| logged out | logged in |
| --- | --- |
| <img width="744" alt="logged-out" src="https://user-images.githubusercontent.com/458784/160412246-b5c44702-2b80-488d-ba48-e038a4a59258.png"> | <img width="744" alt="logged-in" src="https://user-images.githubusercontent.com/458784/160412270-6586593a-4052-4d42-876c-e6b9a1a22992.png"> |

 