### PR TITLE
Update preact-fetching, also fix response destructuring

### DIFF
--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -193,11 +193,11 @@ function AnalyticsEvents({
 }) {
   const [currentUser] = useCurrentUser();
 
-  const queryResult = useQuery(`analyticsEvents:${eventsUrl}`, () =>
+  const { data, isError, error } = useQuery(`analyticsEvents:${eventsUrl}`, () =>
     window
       .fetch(eventsUrl)
       .then((response) => response.json())
-      .then((events: AnalyticsEvent[]) => events)
+      .then(({ events }: { events: AnalyticsEvent[] }) => events)
   );
 
   useEffect(() => {
@@ -205,10 +205,10 @@ function AnalyticsEvents({
   });
 
   if (currentUser) {
-    if (queryResult.isError) {
-      return <ErrorPage url={eventsUrl} error={queryResult.error} />;
+    if (isError) {
+      return <ErrorPage url={eventsUrl} error={error} />;
     }
-    return <Events events={queryResult.data || []} sidenav={sidenav} />;
+    return <Events events={data || []} sidenav={sidenav} />;
   }
   return (
     <Alert heading="Error loading event definitions">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2651,9 +2651,9 @@
       }
     },
     "node_modules/preact-fetching": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/preact-fetching/-/preact-fetching-0.1.0.tgz",
-      "integrity": "sha512-c8JMyILgouXMv5dfskFaDvWCDQQbCzTC8kknClybOSGFPhaU7+gAlX7OTUM5yVBSEyVfnMOBBJ3Cc1Hr6leBqw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/preact-fetching/-/preact-fetching-0.1.1.tgz",
+      "integrity": "sha512-i1SwOrkXnco2ZEGkLGc3P80jsn4noG6XT4rlXMA6rfQrGc1SwocHTr8Oxo30twrF+dCK4sAKQKlxY5Wwt0fsSA==",
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -5025,9 +5025,9 @@
       "integrity": "sha512-dgxpTFV2vs4vizwKohYKkk7g7rmp1wOOcfd4Tz3IB3Wi+ivZzsn/SpeKJhRENSE+n8sUfsAl4S3HiCVT923ABw=="
     },
     "preact-fetching": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/preact-fetching/-/preact-fetching-0.1.0.tgz",
-      "integrity": "sha512-c8JMyILgouXMv5dfskFaDvWCDQQbCzTC8kknClybOSGFPhaU7+gAlX7OTUM5yVBSEyVfnMOBBJ3Cc1Hr6leBqw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/preact-fetching/-/preact-fetching-0.1.1.tgz",
+      "integrity": "sha512-i1SwOrkXnco2ZEGkLGc3P80jsn4noG6XT4rlXMA6rfQrGc1SwocHTr8Oxo30twrF+dCK4sAKQKlxY5Wwt0fsSA==",
       "requires": {}
     },
     "preact-markup": {


### PR DESCRIPTION
Two separate things, I thought I already fixed the first one but apparently not

1. Update `preact-fetching` so we can destructure `data` and `error` in the same line
2. Fix the structure of destructuring analytics events JSON, I got it wrong in #241 