### PR TITLE
Add login-ada Slack handle to Slack article

### DIFF
--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -38,6 +38,7 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 - `@login-appdev-team` Group for application development teams
 - `@login_leads` login team leads
 - `@login-feds` Group for Login.gov federal FTE employees
+- `@login-ada` To tag Team Ada, one of the AppDev teams that works on the IdP
 - `@login-grace` To tag Team Grace, one of the AppDev teams that works on the IdP
 - `@login-katherine` To tag Team Katherine, one of the AppDev teams that works on the IdP and the brochure site
 - `@github-admins-login` members of this group can edit [`identity-core`](https://github.com/orgs/18F/teams/identity-core) GitHub team membership

--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -38,9 +38,9 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 - `@login-appdev-team` Group for application development teams
 - `@login_leads` login team leads
 - `@login-feds` Group for Login.gov federal FTE employees
-- `@login-ada` To tag Team Ada, one of the AppDev teams that works on the IdP
-- `@login-grace` To tag Team Grace, one of the AppDev teams that works on the IdP
-- `@login-katherine` To tag Team Katherine, one of the AppDev teams that works on the IdP and the brochure site
+- `@login-ada` To tag members of [Team Ada]({% link _articles/sprint-teams.md %}#ada)
+- `@login-grace` To tag members of [Team Grace]({% link _articles/sprint-teams.md %}#grace)
+- `@login-katherine` To tag members of [Team Katherine]({% link _articles/sprint-teams.md %}#katherine)
 - `@github-admins-login` members of this group can edit [`identity-core`](https://github.com/orgs/18F/teams/identity-core) GitHub team membership
 
 ## Channels


### PR DESCRIPTION
**Why**: As a Login.gov team member, I want to know each of the team Slack handles, so that I can easily get in contact with the team if I need to.