### PR TITLE
Bump PrivateEye dependency for first-party type definitions

### DIFF
--- a/assets/js/private-links.tsx
+++ b/assets/js/private-links.tsx
@@ -1,7 +1,8 @@
 import PrivateEye from "@18f/private-eye";
 
 export const loadPrivateEye = () => {
-  PrivateEye({
+  // eslint-disable-next-line no-new
+  new PrivateEye({
     defaultMessage: "This link is private to TTS.",
     ignoreUrls: [
       "18f.slack.com",

--- a/assets/js/setup.tsx
+++ b/assets/js/setup.tsx
@@ -11,7 +11,8 @@ export const loadAnchors = () => {
 };
 
 export const loadPrivateEye = () => {
-  PrivateEye({
+  // eslint-disable-next-line no-new
+  new PrivateEye({
     defaultMessage: "This link is private to TTS.",
     ignoreUrls: [
       "18f.slack.com",

--- a/assets/js/typings/@18f/private-eye/index.d.ts
+++ b/assets/js/typings/@18f/private-eye/index.d.ts
@@ -1,6 +1,0 @@
-declare module "@18f/private-eye" {
-  export default function PrivateEye(params: {
-    defaultMessage: string;
-    ignoreUrls: string[];
-  }): void;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@18f/private-eye": "^2.0.0",
+        "@18f/private-eye": "^2.1.0",
         "anchor-js": "^4.2.2",
         "htm": "^3.1.0",
         "identity-style-guide": "^6.3.0",
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@18f/private-eye": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/private-eye/-/private-eye-2.0.0.tgz",
-      "integrity": "sha512-2ZiJSw/frar1pvp+wvRMyvFepVhulN08An9T+y1A8Psfssb72RPkwV9DLM56LO8mEMy/qV/d8e/eAZj1MiYPqA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/private-eye/-/private-eye-2.1.0.tgz",
+      "integrity": "sha512-CQZ2GGckIY91HBQlPVE12HNGPJN3bgvwYJBOC4R3tgTVkNbvdbmXhZycJ9htp9QlK5+I7dG7upm79gigpBqGfg=="
     },
     "node_modules/@babel/runtime": {
       "version": "7.17.7",
@@ -3230,9 +3230,9 @@
       }
     },
     "@18f/private-eye": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@18f/private-eye/-/private-eye-2.0.0.tgz",
-      "integrity": "sha512-2ZiJSw/frar1pvp+wvRMyvFepVhulN08An9T+y1A8Psfssb72RPkwV9DLM56LO8mEMy/qV/d8e/eAZj1MiYPqA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@18f/private-eye/-/private-eye-2.1.0.tgz",
+      "integrity": "sha512-CQZ2GGckIY91HBQlPVE12HNGPJN3bgvwYJBOC4R3tgTVkNbvdbmXhZycJ9htp9QlK5+I7dG7upm79gigpBqGfg=="
     },
     "@babel/runtime": {
       "version": "7.17.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@18f/private-eye": "^2.0.0",
+    "@18f/private-eye": "^2.1.0",
     "anchor-js": "^4.2.2",
     "htm": "^3.1.0",
     "identity-style-guide": "^6.3.0",


### PR DESCRIPTION
**Why**: So that we don't need to maintain them ourselves.

Related:

- https://github.com/18F/private-eye/pull/50
- #235