### PR TITLE
Add a key rotation guide

### DIFF
--- a/_articles/appdev-key-rotation-guide.md
+++ b/_articles/appdev-key-rotation-guide.md
@@ -1,0 +1,7 @@
+---
+title: "Key rotation guide"
+description: "Guide for rotating secrets for the IdP and PKI codebases"
+layout: article
+category: AppDev
+redirect_to: https://docs.google.com/document/d/1mvKQ2lGcjFurAfjn-PNopORHgkamnxpyj8Z4UmGNIi4
+---


### PR DESCRIPTION
**Why**: It was revealed in our most recent wargames that this guide was absent