### PR TITLE
Fix typos/archived repo that I came across while onboarding

### DIFF
--- a/_articles/appdev-proofing-ruby-worker-jobs.md
+++ b/_articles/appdev-proofing-ruby-worker-jobs.md
@@ -54,7 +54,7 @@ The lifecycle of a job:
     - Update the jobs table to mark the job as done, and
     - Store the result (which may contain PII) in Redis, symmetrically encrypted and
       with a 60 second expiration.
-    - PII in the payload may include data from reading the driver's licese
+    - PII in the payload may include data from reading the driver's license
         - First name
         - Last name
         - Date of Birth

--- a/_articles/appdev-risc-ruby-worker-jobs.md
+++ b/_articles/appdev-risc-ruby-worker-jobs.md
@@ -7,7 +7,7 @@ category: "Architecture"
 
 ## Overview
 
-Our implementation of [RISC Security Event Token](https://developers.login.gov/security-events/) uses HTTP Push (basically webhooks) to delivery notifications to partners
+Our implementation of [RISC Security Event Token](https://developers.login.gov/security-events/) uses HTTP Push (basically webhooks) to deliver notifications to partners
 
 To minimize the impact of external HTTP requests on our application performance, we moved those calls to background jobs.
 
@@ -24,7 +24,7 @@ The lifecycle of a job:
     - The JWT payload is constructed and signed in the foreground, and the entire payload body is persisted temporarily as a job argument
     - See [data](#data) for payload contents
 3. Worker host picks up the job and sends it
-   - If the request to the parnter fails, the request will be retried about 5x
+   - If the request to the partner fails, the request will be retried about 5x
 
 ## Data
 

--- a/_articles/github.md
+++ b/_articles/github.md
@@ -23,7 +23,7 @@ View a [list of all repositories](https://github.com/topics/login-gov) tagged fo
 - [**18f/identity-dashboard**](https://github.com/18f/identity-dashboard)
   Partner Dashboard for viewing and editing service provider configurations (only in the INT environment).
 
-- [**18f/identity-charts**](https://github.com/18f/identity-charts) <br />
+- [**18f/identity-charts**](https://github.com/18f/identity-charts){: .deprecated-link} (Archived) <br />
   [login-charts-server.app.cloud.gov](https://login-charts-server.app.cloud.gov/)<br />
   Metrics dashboard for Login.gov
 
@@ -103,8 +103,8 @@ View a [list of all repositories](https://github.com/topics/login-gov) tagged fo
   Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
   A site to disambiguate the Login.gov's predecessor `connect.gov` from Connecticut's ConnectCT `connect.ct.gov`
 
-- [**18f/identity-partners-site**](https://github.com/18F/identity-partners-site/pull/1)<br />
-  Eventually <https://partners.login.gov> but temporarily preview at <https://cg-23777731-2d5f-44ad-8cd2-5dc27ca6af07.app.cloud.gov/preview/18f/identity-partners-site/initial-content/> <br />
+- [**18f/identity-partners-site**](https://github.com/18F/identity-partners-site)<br />
+  [https://partners.login.gov](partners.login.gov) <br />
   Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
   A site to present information for partners
 

--- a/_articles/github.md
+++ b/_articles/github.md
@@ -104,7 +104,7 @@ View a [list of all repositories](https://github.com/topics/login-gov) tagged fo
   A site to disambiguate the Login.gov's predecessor `connect.gov` from Connecticut's ConnectCT `connect.ct.gov`
 
 - [**18f/identity-partners-site**](https://github.com/18F/identity-partners-site)<br />
-  [https://partners.login.gov](partners.login.gov) <br />
+  [partners.login.gov](https://partners.login.gov) <br />
   Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
   A site to present information for partners
 


### PR DESCRIPTION
Fixes a few minor issues I noticed while onboarding to Login.gov