### PR TITLE
Remove sudo from appdev deploy step commands

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -155,9 +155,9 @@ Scheduled for every Thursday
    ```
    On the remote box
    ```bash
-   sudo tail -f /var/log/cloud-init-output.log
+   tail -f /var/log/cloud-init-output.log
    # OR
-   sudo tail -f /var/log/syslog
+   tail -f /var/log/syslog
    ```
    Check the log output to make sure that `db:migrate` runs cleanly. Check for `All done! provision.sh finished for identity-devops` which indicates everything has run
 


### PR DESCRIPTION
**Why**: Because you no longer need to (and cannot) use sudo, so the example command may cause some confusion in its current form.