### PR TITLE
Normalize sprint team data to a .yml file

### DIFF
--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -41,7 +41,7 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 - `@login-feds` Group for Login.gov federal FTE employees
 - `@github-admins-login` members of this group can edit [`identity-core`](https://github.com/orgs/18F/teams/identity-core) GitHub team membership
 
-#### Sprint Teams
+### Sprint Team Handles
 
 {% comment %}
 see data/sprint_teams.yml for the data
@@ -49,11 +49,9 @@ see data/sprint_teams.yml for the data
 
 {% assign sprint_team_handles = site.data.sprint_teams | sort: "name" %}
 
-{% for sprint_team in sprint_team_handles %}
-{% for slack_group_name in sprint_team.slack_group_names %}
-- `@{{ slack_group_name }}` To tag members of [{{ sprint_team.name }}]({% link _articles/sprint-teams.md %}#{{ sprint_team.name | slugify }})
-{%- endfor -%}
-{%- endfor %}
+{% for sprint_team in sprint_team_handles %}{% if sprint_team.slack_group_name %}
+- `@{{ sprint_team.slack_group_name }}` To tag members of [{{ sprint_team.name }}]({% link _articles/sprint-teams.md %}#{{ sprint_team.name | slugify }})
+{%- endif %}{%- endfor %}
 
 
 ## Channels

--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -117,20 +117,6 @@ Here are some common Slack Channels for the Login.gov team
 - [`#login-reporting`](https://gsa-tts.slack.com/archives/C5E7EJWF7):
   Analytics and reporting channel
 
-{% comment %}
-see data/sprint_teams.yml for the data
-{% endcomment %}
-
-{% assign sprint_team_channels = site.data.sprint_teams | sort: "name" %}
-
-{% for sprint_team in sprint_team_channels %}
-{% if sprint_team.slack_channel_name and sprint_team.slack_channel_url %}
-- [`#{{ sprint_team.slack_channel_name }}`]({{ sprint_team.slack_channel_url }})
-  {% include tag.html name='appdev' color='bg-blue' %}
-  Team {{ sprint_team.name }} channel
-{% endif %}
-{% endfor %}
-
 #### Engineering/DevOps
 
 - [`#login-devops`](https://gsa-tts.slack.com/archives/C16RSBG49):
@@ -170,6 +156,21 @@ see data/sprint_teams.yml for the data
 
 - [`#login-product-strategy`](https://gsa-tts.slack.com/archives/CR2SSAFRQ):
   Cross-team product strategy
+
+#### Sprint Teams
+
+{% comment %}
+see data/sprint_teams.yml for the data
+{% endcomment %}
+
+{% assign sprint_team_channels = site.data.sprint_teams | sort: "name" %}
+
+{% for sprint_team in sprint_team_channels %}
+{% if sprint_team.slack_channel_name and sprint_team.slack_channel_url %}
+- [`#{{ sprint_team.slack_channel_name }}`]({{ sprint_team.slack_channel_url }})
+  Team {{ sprint_team.name }} channel
+{% endif %}
+{% endfor %}
 
 ### Other Channels
 

--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -39,10 +39,22 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 - `@login-appdev-team` Group for application development teams
 - `@login_leads` login team leads
 - `@login-feds` Group for Login.gov federal FTE employees
-- `@login-ada` To tag members of [Team Ada]({% link _articles/sprint-teams.md %}#ada)
-- `@login-grace` To tag members of [Team Grace]({% link _articles/sprint-teams.md %}#grace)
-- `@login-katherine` To tag members of [Team Katherine]({% link _articles/sprint-teams.md %}#katherine)
 - `@github-admins-login` members of this group can edit [`identity-core`](https://github.com/orgs/18F/teams/identity-core) GitHub team membership
+
+#### Sprint Teams
+
+{% comment %}
+see data/sprint_teams.yml for the data
+{% endcomment %}
+
+{% assign sprint_team_handles = site.data.sprint_teams | sort: "name" %}
+
+{% for sprint_team in sprint_team_handles %}
+{% for slack_group_name in sprint_team.slack_group_names %}
+- `@{{ slack_group_name }}` To tag members of [{{ sprint_team.name }}]({% link _articles/sprint-teams.md %}#{{ sprint_team.name | slugify }})
+{%- endfor -%}
+{%- endfor %}
+
 
 ## Channels
 
@@ -104,24 +116,22 @@ Here are some common Slack Channels for the Login.gov team
   {% include tag.html name='appdev' color='bg-blue' %}
   General IDP and Appdev matters
 
-- [`#login-ada`](https://gsa-tts.slack.com/archives/CNCGEHG1G):
-  {% include tag.html name='appdev' color='bg-blue' %}
-  Team Ada channel
-
-- [`#login-grace`](https://gsa-tts.slack.com/archives/C0184P9SCJ0):
-  {% include tag.html name='appdev' color='bg-blue' %}
-  Team Grace channel
-
-- [`#login-katherine`](https://gsa-tts.slack.com/archives/C01710KMYUB):
-  {% include tag.html name='appdev' color='bg-blue' %}
-  Team Katherine channel
-
-- [`#login-ursula`](https://gsa-tts.slack.com/archives/C01SU3NB9T3):
-  {% include tag.html name='appdev' color='bg-blue' %}
-  Team Ursula channel
-
 - [`#login-reporting`](https://gsa-tts.slack.com/archives/C5E7EJWF7):
   Analytics and reporting channel
+
+{% comment %}
+see data/sprint_teams.yml for the data
+{% endcomment %}
+
+{% assign sprint_team_channels = site.data.sprint_teams | sort: "name" %}
+
+{% for sprint_team in sprint_team_channels %}
+{% if sprint_team.slack_channel_name and sprint_team.slack_channel_url %}
+- [`#{{ sprint_team.slack_channel_name }}`]({{ sprint_team.slack_channel_url }})
+  {% include tag.html name='appdev' color='bg-blue' %}
+  Team {{ sprint_team.name }} channel
+{% endif %}
+{% endfor %}
 
 #### Engineering/DevOps
 

--- a/_articles/sprint-teams.md
+++ b/_articles/sprint-teams.md
@@ -7,88 +7,18 @@ category: "Team"
 
 Here are the Login.gov sprint teams, most of them are named after famous women in STEM fields.
 
-## Ada
+{% comment %}
+see data/sprint_teams.yml for the data
+{% endcomment %}
 
-* **Namesake**: [Ada Lovelace][ada], one of the world's first computer
-  programmers
-* **Focus area**: Unsupervised remote proofing
+{% assign sprint_teams = site.data.sprint_teams | sort: "name" %}
 
-[ada]: https://en.wikipedia.org/wiki/Ada_Lovelace
+{% for sprint_team in sprint_teams %}
+## {{ sprint_team.name }}
 
-## Agnes
+{% if sprint_team.namesake_markdown -%}
+* **Namesake**: {{ sprint_team.namesake_markdown }}
+{%- endif %}
+* **Focus area**: {{ sprint_team.focus_area }}
 
-* **Namesake**: [Agnes Meyer Driscoll][agnes], a navy cryptanalyst, known as the '[first lady of naval cryptology](https://www.hmdb.org/m.asp?m=106127)'
-* **Focus area**: Attempts API
-
-[agnes]: https://www.nsa.gov/History/Cryptologic-History/Historical-Figures/Historical-Figures-View/Article/1623020/agnes-meyer-driscoll/
-
-## Grace
-
-* **Namesake**: [Admiral Grace Hopper][grace], a computer scientist
-  and navy officer
-* **Focus area**: Inherited proofing
-
-[grace]: https://en.wikipedia.org/wiki/Grace_Hopper
-
-## IDVA
-
-* **Focus area**: Equity Study & API
-
-## Joy
-
-* **Namesake**: [Dr. Joy Buolamwini][joy], a computer scientist, artist, and
-  activist who has published foundational work on algorithmic discrimination.
-* **Focus area**: In Person Proofing
-
-[joy]: https://en.wikipedia.org/wiki/Joy_Buolamwini
-
-## Judy
-
-* **Namesake**: [Judy Parsons][judy], As a code breaker working with a secret
-  unit in the US Navy, Parsons was instrumental in deciphering the enemy’s
-  secret codes, but her work went unacknowledged for decades after the war.
-* **Focus area**: Cybersecurity and Anti-Fraud work stream
-
-[judy]: https://blog.theveteranssite.greatergood.com/wwii-navy-codebreaker/
-
-## Katherine
-
-* **Namesake**: [Katherine Johnson][katherine], a mathematician
-  who was a key part of early NASA spaceflights
-* **Focus area**: Authentication
-
-[katherine]: https://en.wikipedia.org/wiki/Katherine_Johnson
-
-## Kimberly
-
-* **Namesake**: [Kimberly Bryant][kimberly], an electrical engineer who founded
-  [Black Girls Code](https://www.blackgirlscode.com/).
-* **Focus area**: Partnerships Account Managers and Account Management Coordinators
-
-[kimberly]: https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist)
-
-## Mary
-
-* **Namesake**: [Mary Poppendieck][mary], a computer scientist and
-  visionary in the application of lean manufacturing principles to the world
-  of software development
-* **Focus area**: _Developer Experience_: A new software factory and minimal platform to
-  speed our secure development processes
-
-[mary]: http://www.poppendieck.com/people.htm
-
-## Radia
-
-* **Namesake**: [Radia Perlman][radia], the inventor of the spanning-tree protocol
-* **Focus area**: _Cloud Infrastructure_: The cloud architectures and resources that make
-  up our minimal platform
-
-[radia]: https://en.wikipedia.org/wiki/Radia_Perlman
-
-## Ursula
-
-* **Namesake**: [Ursula Burns][ursula], who has been CEO of technology
-  companies like Xerox
-* **Focus area**: Partnership website and partner console
-
-[ursula]: https://en.wikipedia.org/wiki/Ursula_Burns
+{% endfor %}

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -8,7 +8,7 @@
 - name: Agnes
   namesake_markdown: "[Agnes Meyer Driscoll](https://www.nsa.gov/History/Cryptologic-History/Historical-Figures/Historical-Figures-View/Article/1623020/agnes-meyer-driscoll/), a navy cryptanalyst, known as the '[first lady of naval cryptology](https://www.hmdb.org/m.asp?m=106127)'"
   focus_area: Attempts API
-  slack_channel_name: login-team-loggerhead
+  slack_channel_name: login-team-agnes
   slack_channel_url: https://gsa-tts.slack.com/archives/C03N6KQBAKS
 
 - name: Grace

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -1,0 +1,71 @@
+- name: Ada
+  namesake_markdown: "[Ada Lovelace](https://en.wikipedia.org/wiki/Ada_Lovelace), one of the world's first computer programmers"
+  focus_area: Unsupervised remote proofing
+  slack_channel_name: login-team-ada
+  slack_channel_url: https://gsa-tts.slack.com/archives/CNCGEHG1G
+  slack_group_names:
+  - login-ada
+
+- name: Agnes
+  namesake_markdown: "[Agnes Meyer Driscoll](https://www.nsa.gov/History/Cryptologic-History/Historical-Figures/Historical-Figures-View/Article/1623020/agnes-meyer-driscoll/), a navy cryptanalyst, known as the '[first lady of naval cryptology](https://www.hmdb.org/m.asp?m=106127)'"
+  focus_area: Attempts API
+  slack_channel_name: login-team-loggerhead
+  slack_channel_url: https://gsa-tts.slack.com/archives/C03N6KQBAKS
+
+- name: Grace
+  namesake_markdown: "[Admiral Grace Hopper](https://en.wikipedia.org/wiki/Grace_Hopper), a computer scientist and navy officer"
+  focus_area: KYC/Non-biometric verification
+  slack_channel_name: login-team-grace
+  slack_channel_url: https://gsa-tts.slack.com/archives/C0184P9SCJ0
+  slack_group_names:
+  - login-grace
+
+- name: IDVA
+  focus_area: "Equity Study & API"
+  slack_channel_name: identity-idva
+  slack_channel_url: https://gsa-tts.slack.com/archives/C017KUF5DL4
+
+- name: Joy
+  namesake_markdown: "[Dr. Joy Buolamwini](https://en.wikipedia.org/wiki/Joy_Buolamwini), a computer scientist, artist, and activist who has published foundational work on algorithmic discrimination."
+  focus_area: In Person Proofing
+  slack_channel_name: login-team-joy
+  slack_channel_url: https://gsa-tts.slack.com/archives/C03FA4VBN76
+  slack_group_names:
+  - login-joy-engineers
+  - login-joy-designers
+
+- name: Judy
+  namesake_markdown: "[Judy Parsons](https://blog.theveteranssite.greatergood.com/wwii-navy-codebreaker/), As a code breaker working with a secret unit in the US Navy, Parsons was instrumental in deciphering the enemy’s secret codes, but her work went unacknowledged for decades after the war."
+  focus_area: Cybersecurity and Anti-Fraud work stream
+  slack_channel_url: https://gsa-tts.slack.com/archives/C03A12WPCLW
+  slack_channel_name: login-team-judy
+
+- name: Kimberly
+  namesake_markdown: "[Kimberly Bryant](https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist), an electrical engineer who founded [Black Girls Code](https://www.blackgirlscode.com/)."
+  focus_area: Partnerships Account Managers and Account Management Coordinators
+  slack_channel_url: https://gsa-tts.slack.com/archives/C03B3AQQH0C
+  slack_channel_name: login-team-kimberly
+
+- name: Katherine
+  namesake_markdown: "[Katherine Johnson](https://en.wikipedia.org/wiki/Katherine_Johnson), a mathematician who was a key part of early NASA spaceflights"
+  focus_area: Authentication
+  slack_channel_url: https://gsa-tts.slack.com/archives/C01710KMYUB
+  slack_channel_name: login-team-katherine
+
+- name: Mary
+  namesake_markdown: "[Mary Poppendieck](http://www.poppendieck.com/people.htm), a computer scientist and visionary in the application of lean manufacturing principles to the world   of software development"
+  focus_area: "_Developer Experience_: A new software factory and minimal platform to speed our secure development processes"
+  slack_channel_url: https://gsa-tts.slack.com/archives/C023LB27CCQ
+  slack_channel_name: login-team-mary
+
+- name: Radia
+  namesake_markdown: "[Radia Perlman](https://en.wikipedia.org/wiki/Radia_Perlman), the inventor of the spanning-tree protocol"
+  focus_area: "_Cloud Infrastructure_: The cloud architectures and resources that make up our minimal platform"
+  slack_channel_url: https://gsa-tts.slack.com/archives/C01DBBNTL68
+  slack_channel_name: login-team-radia
+
+- name: Ursula
+  namesake_markdown: "[Ursula Burns](https://en.wikipedia.org/wiki/Ursula_Burns), who has been CEO of technology companies like Xerox"
+  focus_area: Partnership website and partner console
+  slack_channel_url: https://gsa-tts.slack.com/archives/C01SU3NB9T3
+  slack_channel_name: login-team-ursula

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -41,7 +41,7 @@
   slack_channel_name: login-team-judy
 
 - name: Kimberly
-  namesake_markdown: "[Kimberly Bryant](https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist), an electrical engineer who founded [Black Girls Code](https://www.blackgirlscode.com/)."
+  namesake_markdown: "[Kimberly Bryant](https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist)), an electrical engineer who founded [Black Girls Code](https://www.blackgirlscode.com/)."
   focus_area: Partnerships Account Managers and Account Management Coordinators
   slack_channel_url: https://gsa-tts.slack.com/archives/C03B3AQQH0C
   slack_channel_name: login-team-kimberly

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -3,8 +3,7 @@
   focus_area: Unsupervised remote proofing
   slack_channel_name: login-team-ada
   slack_channel_url: https://gsa-tts.slack.com/archives/CNCGEHG1G
-  slack_group_names:
-  - login-ada
+  slack_group_name: login-ada
 
 - name: Agnes
   namesake_markdown: "[Agnes Meyer Driscoll](https://www.nsa.gov/History/Cryptologic-History/Historical-Figures/Historical-Figures-View/Article/1623020/agnes-meyer-driscoll/), a navy cryptanalyst, known as the '[first lady of naval cryptology](https://www.hmdb.org/m.asp?m=106127)'"
@@ -17,8 +16,7 @@
   focus_area: KYC/Non-biometric verification
   slack_channel_name: login-team-grace
   slack_channel_url: https://gsa-tts.slack.com/archives/C0184P9SCJ0
-  slack_group_names:
-  - login-grace
+  slack_group_name: login-grace
 
 - name: IDVA
   focus_area: "Equity Study & API"
@@ -30,9 +28,7 @@
   focus_area: In Person Proofing
   slack_channel_name: login-team-joy
   slack_channel_url: https://gsa-tts.slack.com/archives/C03FA4VBN76
-  slack_group_names:
-  - login-joy-engineers
-  - login-joy-designers
+  slack_group_name: login-joy
 
 - name: Judy
   namesake_markdown: "[Judy Parsons](https://blog.theveteranssite.greatergood.com/wwii-navy-codebreaker/), As a code breaker working with a secret unit in the US Navy, Parsons was instrumental in deciphering the enemy’s secret codes, but her work went unacknowledged for decades after the war."


### PR DESCRIPTION
This might be a little less accessible to maintain, so I am open to just discarding it, but it seems like the more teams we onboard, the easier it would be to track various fields and make sure they get formatted properly?
