### PR TITLE
Link to RFC template, deprecate Engineering Design template

### DIFF
--- a/_articles/eng-design-doc.md
+++ b/_articles/eng-design-doc.md
@@ -3,5 +3,6 @@ title: "Engineering Design Doc Template"
 layout: article
 category: "AppDev"
 redirect_to: https://docs.google.com/document/d/1KlQL4MMCXahV12mMbh5scmXLl6adjv_0fcFzQ8si7qc/edit#
-description: "Template that can be copied for engineering proposals"
+description: "Template that can be copied for engineering proposals, replaced in favor of [RFCs](#rfcs)"
+deprecated: true
 ---

--- a/_articles/rfc-template.md
+++ b/_articles/rfc-template.md
@@ -1,0 +1,7 @@
+---
+title: 'RFC Template <a id="rfcs" />'
+layout: article
+category: "Team"
+redirect_to: "https://docs.google.com/document/d/1-M5Iy_z2M0gfZJTd_JJfHaToa8HRc8E40fJpgCFRSjc/edit"
+description: '"Requests for Comments" or Pitches, see [folder of existing RFCs](https://drive.google.com/drive/folders/19gDt7iCpiKIcxRrGabFHvKOfLUTg6zdv?ths=true)'
+---


### PR DESCRIPTION
Preserves links as a deprecated archive. I updated the template doc itself with a similar deprecation notice

| | screenshot |
| --- | --- |
| new item | <img width="505" alt="Screen Shot 2022-08-01 at 10 12 47 AM" src="https://user-images.githubusercontent.com/458784/182206432-a4ae0426-30a4-4319-b694-4c5900f25a02.png"> |
| old item | <img width="523" alt="Screen Shot 2022-08-01 at 10 12 57 AM" src="https://user-images.githubusercontent.com/458784/182206435-4bce356a-3c73-47d3-9fe1-7b9cc41c4cc7.png"> |

