### PR TITLE
Add Slack links to sprint-teams.md

### DIFF
--- a/_articles/sprint-teams.md
+++ b/_articles/sprint-teams.md
@@ -20,5 +20,8 @@ see data/sprint_teams.yml for the data
 * **Namesake**: {{ sprint_team.namesake_markdown }}
 {%- endif %}
 * **Focus area**: {{ sprint_team.focus_area }}
+{% if sprint_team.slack_channel_url -%}
+* **Slack**: [#{{ sprint_team.slack_channel_name }}]({{ sprint_team.slack_channel_url }})
+{%- endif %}
 
 {% endfor %}


### PR DESCRIPTION
I see in `main/_data/sprint_teams.yml` that we have both a `slack_channel_name` and `slack_channel_url` as variables, but I don't see them on our Sprint Teams page. Maybe that's intentional, but it seems helpful if we point people to this Handbook page?