### PR TITLE
Add a style for a highlighted target

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,3 +38,15 @@
 .deprecated-link {
   color: gray;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  &:target {
+    background-color: #fcf197; // TODO: use color('warning-light');
+  }
+}


### PR DESCRIPTION
- Used when linking to a particular anchor in the handbook

Example

<img width="564" alt="Screen Shot 2022-09-06 at 1 06 23 PM" src="https://user-images.githubusercontent.com/458784/188728589-6811a081-616f-46e7-8e59-733b7ba32802.png">
