### PR TITLE
Upgrade, use design system utilities for color reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,10 @@ collections:
   articles: # individual articles
     output: true
 
+sass:
+  load_paths:
+    - node_modules
+
 copy_to_destination:
   - node_modules/identity-style-guide/dist/assets
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,7 +4,9 @@
 @charset 'utf-8';
 
 // Imports
-@import 'styles.css';
+@import "styles.css";
+@import "identity-style-guide/dist/assets/scss/packages/required";
+@import "identity-style-guide/dist/assets/scss/packages/utilities";
 
 // Hello! These styles are specific styles for
 // the Login.gov Handbook. Please refer to design.login.login-gov
@@ -12,7 +14,6 @@
 
 // Search
 #search-results {
-
   background-color: #ebf3fa;
   position: absolute;
   top: 20px;
@@ -47,6 +48,6 @@ h5,
 h6,
 p {
   &:target {
-    background-color: #fcf197; // TODO: use color('warning-light');
+    background-color: color("warning-light");
   }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,7 +6,6 @@
 // Imports
 @import "styles.css";
 @import "identity-style-guide/dist/assets/scss/packages/required";
-@import "identity-style-guide/dist/assets/scss/packages/utilities";
 
 // Hello! These styles are specific styles for
 // the Login.gov Handbook. Please refer to design.login.login-gov

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "identity-handbook",
       "dependencies": {
         "@18f/private-eye": "^2.1.0",
         "anchor-js": "^4.2.2",
         "htm": "^3.1.0",
-        "identity-style-guide": "^6.3.0",
+        "identity-style-guide": "^6.5.0",
         "js-yaml": "^4.1.0",
         "marked": "^4.0.12",
         "preact": "^10.6.6",
@@ -240,9 +241,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -365,9 +366,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -676,9 +677,9 @@
       }
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
+      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -742,9 +743,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -803,12 +804,12 @@
     "node_modules/domready": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw="
+      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
     },
     "node_modules/element-closest": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw=",
+      "integrity": "sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg==",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1421,7 +1422,7 @@
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -1524,13 +1525,17 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
-      "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1940,12 +1945,12 @@
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "node_modules/identity-style-guide": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.3.0.tgz",
-      "integrity": "sha512-dmQNHo84HQmNitAt8mt0Rb/kxADJ3ZE7jmwrrSRPSrTh8t6N37ORh1gBjk/qeCGWnZHYnIcGA2bYmUmr6WuEHQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
+      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
       "dependencies": {
-        "domready": "^1.0.8",
-        "uswds": "^2.13.1"
+        "domready": "1.0.8",
+        "uswds": "^2.13.3"
       },
       "engines": {
         "node": ">=12",
@@ -2057,9 +2062,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -2270,7 +2275,7 @@
     "node_modules/keyboardevent-key-polyfill": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
+      "integrity": "sha512-NTDqo7XhzL1fqmUzYroiyK2qGua7sOMzLav35BfNA/mPUSCtw8pZghHFMTYR9JdnJ23IQz695FcaM6EE6bpbFQ=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
@@ -2748,7 +2753,7 @@
     "node_modules/receptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/receptor/-/receptor-1.0.0.tgz",
-      "integrity": "sha1-v1RHfgOH5Evr84VRILvaWt6gj4s=",
+      "integrity": "sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==",
       "dependencies": {
         "element-closest": "^2.0.1",
         "keyboardevent-key-polyfill": "^1.0.2",
@@ -2791,12 +2796,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -2819,7 +2824,7 @@
     "node_modules/resolve-id-refs": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/resolve-id-refs/-/resolve-id-refs-0.1.0.tgz",
-      "integrity": "sha1-MSZiS4h0idqPwK6IljL4QTrGw+w="
+      "integrity": "sha512-hNS03NEmVpJheF7yfyagNh57XuKc0z+NkSO0oBbeO67o6IJKoqlDfnNIxhjp7aTWwjmSWZQhtiGrOgZXVyM90w=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -3145,15 +3150,15 @@
       }
     },
     "node_modules/uswds": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.1.tgz",
-      "integrity": "sha512-tl4bSB+0ejZw90gwqsbO5XA+1b9nnGdbvVhY4ARGKoTIJ7M8/vpUBoz+Tm327ATZI2LUWmoced5V986muq1Iew==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
+      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
       "dependencies": {
-        "classlist-polyfill": "^1.0.3",
-        "domready": "^1.0.8",
-        "object-assign": "^4.1.1",
-        "receptor": "^1.0.0",
-        "resolve-id-refs": "^0.1.0"
+        "classlist-polyfill": "1.0.3",
+        "domready": "1.0.8",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
       },
       "engines": {
         "node": ">= 4"
@@ -3355,9 +3360,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -3420,9 +3425,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -3643,9 +3648,9 @@
       }
     },
     "classlist-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
+      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -3698,9 +3703,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -3742,12 +3747,12 @@
     "domready": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw="
+      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
     },
     "element-closest": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw="
+      "integrity": "sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -4118,7 +4123,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -4184,13 +4189,14 @@
           }
         },
         "resolve": {
-          "version": "2.0.0-next.3",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
-          "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
       }
@@ -4508,12 +4514,12 @@
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "identity-style-guide": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.3.0.tgz",
-      "integrity": "sha512-dmQNHo84HQmNitAt8mt0Rb/kxADJ3ZE7jmwrrSRPSrTh8t6N37ORh1gBjk/qeCGWnZHYnIcGA2bYmUmr6WuEHQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
+      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
       "requires": {
-        "domready": "^1.0.8",
-        "uswds": "^2.13.1"
+        "domready": "1.0.8",
+        "uswds": "^2.13.3"
       }
     },
     "ignore": {
@@ -4591,9 +4597,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4741,7 +4747,7 @@
     "keyboardevent-key-polyfill": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
+      "integrity": "sha512-NTDqo7XhzL1fqmUzYroiyK2qGua7sOMzLav35BfNA/mPUSCtw8pZghHFMTYR9JdnJ23IQz695FcaM6EE6bpbFQ=="
     },
     "language-subtag-registry": {
       "version": "0.3.21",
@@ -5089,7 +5095,7 @@
     "receptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/receptor/-/receptor-1.0.0.tgz",
-      "integrity": "sha1-v1RHfgOH5Evr84VRILvaWt6gj4s=",
+      "integrity": "sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==",
       "requires": {
         "element-closest": "^2.0.1",
         "keyboardevent-key-polyfill": "^1.0.2",
@@ -5120,12 +5126,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -5139,7 +5145,7 @@
     "resolve-id-refs": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/resolve-id-refs/-/resolve-id-refs-0.1.0.tgz",
-      "integrity": "sha1-MSZiS4h0idqPwK6IljL4QTrGw+w="
+      "integrity": "sha512-hNS03NEmVpJheF7yfyagNh57XuKc0z+NkSO0oBbeO67o6IJKoqlDfnNIxhjp7aTWwjmSWZQhtiGrOgZXVyM90w=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -5368,15 +5374,15 @@
       }
     },
     "uswds": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.1.tgz",
-      "integrity": "sha512-tl4bSB+0ejZw90gwqsbO5XA+1b9nnGdbvVhY4ARGKoTIJ7M8/vpUBoz+Tm327ATZI2LUWmoced5V986muq1Iew==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
+      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
       "requires": {
-        "classlist-polyfill": "^1.0.3",
-        "domready": "^1.0.8",
-        "object-assign": "^4.1.1",
-        "receptor": "^1.0.0",
-        "resolve-id-refs": "^0.1.0"
+        "classlist-polyfill": "1.0.3",
+        "domready": "1.0.8",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
       }
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@18f/private-eye": "^2.1.0",
     "anchor-js": "^4.2.2",
     "htm": "^3.1.0",
-    "identity-style-guide": "^6.3.0",
+    "identity-style-guide": "^6.5.0",
     "js-yaml": "^4.1.0",
     "marked": "^4.0.12",
     "preact": "^10.6.6",


### PR DESCRIPTION
Follow-up to TODO item in #308

- Upgrades `identity-style-guide` dependency from `6.3.0` to `6.5.0` to take advantage of latest bug fixes and improvements.
- Imports design system utility methods to avoid hard-coded reference to color value.
   - This project [uses the precompiled stylesheet](https://github.com/18F/identity-handbook/blob/dca78d9ed4649c741858bb63a09cb47bb44271e6/_config.yml#L16-L17) shipped through the design system, hence why utility methods are not available by default.

There should be no visual impact by these changes. Test to ensure that the behavior added in #308 continues to work.