### PR TITLE
Add anchors to links to external articles

### DIFF
--- a/_includes/articles_category.md
+++ b/_includes/articles_category.md
@@ -17,10 +17,12 @@ includes:
 #### {{ subcategory }}
 
 {%     for article in articles %}
- - [{{article.title}}]({% include article_url.txt article=article %})
+ - <span markdown="1" {% if article.redirect_to %}data-anchor{% endif %}>
+   [{{article.title}}]({% include article_url.txt article=article %})
      {%- if article.deprecated -%}
        {: .deprecated-link} (deprecated)
      {%- endif -%}
+    </span>
      {% if article.description %}<br/>{{ article.description }}{% endif %}
 {%     endfor %}
 {%   endif %}
@@ -34,10 +36,12 @@ includes:
 
 {% for article in articles_no_subcategory %}
 {% unless article.subcategory %}
- - [{{article.title}}]({% include article_url.txt article=article %})
+ - <span markdown="1" {% if article.redirect_to %}data-anchor{% endif %}>
+   [{{article.title}}]({% include article_url.txt article=article %})
    {%- if article.deprecated -%}
     {: .deprecated-link} (deprecated)
    {%- endif -%}
+   </span>
    {% if article.description %}<br/>{{ article.description }}{% endif %}
 {% endunless %}
 {% endfor %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -45,7 +45,9 @@ h3,
 h4,
 h5,
 h6,
-p {
+p,
+a,
+span {
   &:target {
     background-color: color("warning-light");
   }


### PR DESCRIPTION
**Why**: If we have a private google doc that's
findable from the handbook, I want to be able to link to the handbook for where to find that article

Example
- before, you could use Chrome's ["link to snippet"](https://handbook.login.gov/#:~:text=Environment%20Descriptions%0AListing%20of%20environments%20and%20the%20differences%20between%20them%2C%20like%20prod%2C%20pt%2C%20dm%2C%20int%20or%20dev)
- now, you get a little anchor UI element and a specific ID

| before | after |
| ---- | ---- |
|  <img width="660" alt="Screen Shot 2022-09-08 at 3 25 58 PM" src="https://user-images.githubusercontent.com/458784/189236810-9828de03-ccb2-4a1d-9e52-6c834d9a2a2f.png"> | <img width="513" alt="Screen Shot 2022-09-08 at 3 26 17 PM" src="https://user-images.githubusercontent.com/458784/189236828-5c5247db-702d-4295-8319-bcd394d2de46.png"> |


