### PR TITLE
Add team Readme documents to Sprint Teams page

### DIFF
--- a/_articles/sprint-teams.md
+++ b/_articles/sprint-teams.md
@@ -24,5 +24,8 @@ see data/sprint_teams.yml for the data
 {% if sprint_team.slack_channel_url -%}
 * **Slack**: [#{{ sprint_team.slack_channel_name }}]({{ sprint_team.slack_channel_url }})
 {%- endif %}
+{% if sprint_team.readme -%}
+* **Readme**: [View Team {{sprint_team.name}} Readme]({{ sprint_team.readme }})
+{%- endif %}
 
 {% endfor %}

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -4,12 +4,14 @@
   slack_channel_name: login-team-ada
   slack_channel_url: https://gsa-tts.slack.com/archives/CNCGEHG1G
   slack_group_name: login-ada
+  readme: https://docs.google.com/document/d/1gAJPduXfsPSXYjlyh_8YxbCtZNONa-jBPYut9T8HKE0/edit
 
 - name: Agnes
   namesake_markdown: "[Agnes Meyer Driscoll](https://www.nsa.gov/History/Cryptologic-History/Historical-Figures/Historical-Figures-View/Article/1623020/agnes-meyer-driscoll/), a navy cryptanalyst, known as the '[first lady of naval cryptology](https://www.hmdb.org/m.asp?m=106127)'"
   focus_area: Attempts API
   slack_channel_name: login-team-agnes
   slack_channel_url: https://gsa-tts.slack.com/archives/C03N6KQBAKS
+  readme: https://docs.google.com/document/d/1NQluZ_oo58ER4T49XzCvowdmXEYbOpZf-xS6MoT2Yng/edit
 
 - name: Grace
   namesake_markdown: "[Admiral Grace Hopper](https://en.wikipedia.org/wiki/Grace_Hopper), a computer scientist and navy officer"
@@ -17,6 +19,7 @@
   slack_channel_name: login-team-grace
   slack_channel_url: https://gsa-tts.slack.com/archives/C0184P9SCJ0
   slack_group_name: login-grace
+  readme: https://docs.google.com/document/d/1x_IPoYc_kavE6Rw58leIckp85Js7fKPy_NebpqC3iN0/edit
 
 - name: IDVA
   focus_area: "Equity Study & API"
@@ -29,6 +32,7 @@
   slack_channel_name: login-team-joy
   slack_channel_url: https://gsa-tts.slack.com/archives/C03FA4VBN76
   slack_group_name: login-joy
+  readme: https://docs.google.com/document/d/1WalgBrIBM4-nwKlSj49xdHazpK9dQoOxvuWgTUx2vK0/edit
 
 - name: Judy
   namesake_markdown: "[Judy Parsons](https://blog.theveteranssite.greatergood.com/wwii-navy-codebreaker/), As a code breaker working with a secret unit in the US Navy, Parsons was instrumental in deciphering the enemy’s secret codes, but her work went unacknowledged for decades after the war."
@@ -36,29 +40,33 @@
   slack_channel_url: https://gsa-tts.slack.com/archives/C03A12WPCLW
   slack_channel_name: login-team-judy
 
-- name: Kimberly
-  namesake_markdown: "[Kimberly Bryant](https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist)), an electrical engineer who founded [Black Girls Code](https://www.blackgirlscode.com/)."
-  focus_area: Partnerships Account Managers and Account Management Coordinators
-  slack_channel_url: https://gsa-tts.slack.com/archives/C03B3AQQH0C
-  slack_channel_name: login-team-kimberly
-
 - name: Katherine
   namesake_markdown: "[Katherine Johnson](https://en.wikipedia.org/wiki/Katherine_Johnson), a mathematician who was a key part of early NASA spaceflights"
   focus_area: Authentication
   slack_channel_url: https://gsa-tts.slack.com/archives/C01710KMYUB
   slack_channel_name: login-team-katherine
+  readme: https://docs.google.com/document/d/1K4vlvY-KpMpZPpYsOo0BcUGDSxRVfsEHNTUiZvTDVAI/edit
+
+- name: Kimberly
+  namesake_markdown: "[Kimberly Bryant](https://en.wikipedia.org/wiki/Kimberly_Bryant_(technologist)), an electrical engineer who founded [Black Girls Code](https://www.blackgirlscode.com/)."
+  focus_area: Partnerships Account Managers and Account Management Coordinators
+  slack_channel_url: https://gsa-tts.slack.com/archives/C03B3AQQH0C
+  slack_channel_name: login-team-kimberly
+  readme: https://docs.google.com/document/d/1wTmChCSfiK3Dd2sUuLHa7OYusYCpH75BT7dLIZ2oqio/edit
 
 - name: Mary
   namesake_markdown: "[Mary Poppendieck](http://www.poppendieck.com/people.htm), a computer scientist and visionary in the application of lean manufacturing principles to the world   of software development"
   focus_area: "_Developer Experience_: A new software factory and minimal platform to speed our secure development processes"
   slack_channel_url: https://gsa-tts.slack.com/archives/C023LB27CCQ
   slack_channel_name: login-team-mary
+  readme: https://docs.google.com/document/d/1MVybeUqkBIYz13H2eTi2X0EqW_IhA87ZRq3g-xNWkOc/edit
 
 - name: Radia
   namesake_markdown: "[Radia Perlman](https://en.wikipedia.org/wiki/Radia_Perlman), the inventor of the spanning-tree protocol"
   focus_area: "_Cloud Infrastructure_: The cloud architectures and resources that make up our minimal platform"
   slack_channel_url: https://gsa-tts.slack.com/archives/C01DBBNTL68
   slack_channel_name: login-team-radia
+  readme: https://docs.google.com/document/d/1ckhQZCMdrW-uuxMSy1hIi-C2cE1B-WKEVL8gleC5XBo/edit
 
 - name: Ross
   namesake_markdown: "[Mary G Ross](https://en.wikipedia.org/wiki/Mary_Golda_Ross), the first known Native American female engineer, she worked on the preliminary design concepts for interplanetary space travel, manned space flight, ballistic missiles, and satellites in orbit above the earth"
@@ -71,3 +79,4 @@
   focus_area: Partnership website and partner console
   slack_channel_url: https://gsa-tts.slack.com/archives/C01SU3NB9T3
   slack_channel_name: login-team-ursula
+  readme: https://docs.google.com/document/d/1MkXRjQ3k0UQTu9N4K9N3h30ozmDYjTZFGVz70b_XNj0/edit


### PR DESCRIPTION
**Why**: So that a reader can learn more about the team in the context of reading about each of our teams, and so that someone seeking a Readme has a centralized listing of them.

**Screenshot:**

![image](https://user-images.githubusercontent.com/1779930/189657281-314704c1-ea4d-4a39-a5d5-b4642a8236c5.png)
