### PR TITLE
Update deployment documentation for twice-weekly deployments

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -14,7 +14,7 @@ A few notes on our deploy process.
 ### Cadence
 
 **When to deploy:** ✅
-- Typically we do a full deploy every week on Thursday.
+- Typically we do a full deploy twice weekly, on Mondays and Thursdays.
 
 **When _not_ to deploy:** ❌
 - We try to avoid deploying on Fridays, to minimize the chances of introducing a
@@ -63,7 +63,6 @@ This guide assumes that:
 Note: it is a good idea to make sure you have the latest pulled down from identity-devops - lots of goood improvements all the time!
 
 ### Pre-deploy
-Scheduled for every **Tuesday**
 
 #### Test the proofing flow in staging
 
@@ -134,7 +133,6 @@ The last step may need a force push (add `-f`). Force-pushing to an RC branch is
 Staging used to be deployed by this process, but this was changed to deploy the `main` branch to the staging environment every day. See [daily deploy schedule]({% link _articles/daily-deploy-schedule.md %}) for more details.
 
 ### Production
-Scheduled for every Thursday
 
 1. Merge the production promotion pull request (**NOT** a squashed merge, just a normal merge)
 1. Notify in Slack (`#login-appdev` and `#login-devops` channels)

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -19,8 +19,8 @@ A few notes on our deploy process.
 **When _not_ to deploy:** ❌
 - We try to avoid deploying on Fridays, to minimize the chances of introducing a
   bug and having to scramble to fix it before the weekend
-- During New Years/winter break, or any other time when many team members are
-  on vacation
+- When the deploy falls on a holiday, or any other time when many team members are on vacation, such
+  as New Years / end of year.
 
 ### Types of Deploys
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -29,7 +29,7 @@ the `stages/prod` branch.
 
 | Type | What | When | Who |
 | ---- | ---- | ---- | --- |
-| **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Every week | [@login-deployer][deployer-rotation] |
+| **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Twice a week | [@login-deployer][deployer-rotation] |
 | **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | [@login-deployer][deployer-rotation], or engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
 | **Config Recyle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -178,6 +178,10 @@ Staging used to be deployed by this process, but this was changed to deploy the 
 
     1. Manual Inspection
       - Check [NewRelic (prod.login.gov)](https://one.newrelic.com/nr1-core/errors-ui/overview/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg) for errors
+      - Optionally, use the deploy monitoring script to compare error rates and success rates for critical flows
+        ```bash
+        aws-vault exec prod-power -- ./bin/monitor-deploy prod idp
+        ```
       - If you notice any errors that make you worry, [roll back the deploy](#rolling-back)
 
 1. **PRODUCTION ONLY**: This step is required in production

--- a/_articles/deploying-sp-to-prod.md
+++ b/_articles/deploying-sp-to-prod.md
@@ -18,9 +18,9 @@ Here is a list of items that need to be completed to deploy the configuration fo
 
 5. The PR should be reviewed by another Integration Engineer or Partner Success Engineer and merged into `main`.
 
-6. Let the partner know via ZenDesk that their application has now been deployed and in the bottom right-hand corner click the arrow and select **Submit as Solved**. 
+6. Let the partner know via ZenDesk that their application has now been deployed and in the bottom right-hand corner click the arrow and select **Submit as Solved**.
 
-6. Generally speaking, we rely on the [weekly IdP deployment process]({% link _articles/appdev-deploy.md %}) to pull in configuration changes, especially new integration launches. If a manual deployment is required, follow the directions below:
+6. Generally speaking, we rely on the [recurring IdP deployment process]({% link _articles/appdev-deploy.md %}) to pull in configuration changes, especially new integration launches. If a manual deployment is required, follow the directions below:
   * **If no new logo files are being added in this PR,** you can simply spin up a migration instance in the appropriate environment (replace `prod` with `staging` if deploying integration to staging):
     ```sh
     bin/awsv prod bin/asg-recycle prod migration

--- a/_articles/slack.md
+++ b/_articles/slack.md
@@ -26,7 +26,7 @@ These handles ping oncall engineers, use for emergencies or urgent items.
 
 - `@login-appdev-oncall` The application developer oncall
 - `@login-devops-oncall` The devops oncall
-- `@login-deployer` The weekly [appdev app deployer]({% link _articles/appdev-deploy-rotation.md %})
+- `@login-deployer` The [appdev app deployer]({% link _articles/appdev-deploy-rotation.md %})
 - `@login-devtools-oncall` The devtools developer oncall
 
 ### Team Handles


### PR DESCRIPTION
**Why:** So that the documentation is in sync with our current practices.

- Updates references to deployment days
- Clarifies that deployment is skipped for holidays, since it's more likely now with Monday deploys (e.g. Labor Day)
- Add optional step to use monitoring script for manual inspection