### PR TITLE
Update anchor link headings for dynamic articles

### DIFF
--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -102,18 +102,23 @@ function Event({ event }: { event: AnalyticsEvent }) {
     attributes = [],
   } = event;
 
+  const slug = urlify(eventName);
+  const previousEventSlug = urlify(`${eventName} Previous`);
+  const attributesSlug = urlify(`${eventName} Attributes`);
+  const exampleSlug = urlify(`${eventName} Example`);
+
   return (
     <div>
-      <h3>
+      <h3 id={slug}>
         {eventName}
-        <AnchorLink slug={urlify(eventName)} />
+        <AnchorLink slug={slug} />
       </h3>
       <p>{description}</p>
       {previousEventNames?.length ? (
         <>
-          <h4>
+          <h4 id={previousEventSlug}>
             Previous Event Names
-            <AnchorLink slug={urlify(`${eventName} Previous`)} />
+            <AnchorLink slug={previousEventSlug} />
           </h4>
           <ul>
             {previousEventNames.map((name) => (
@@ -124,9 +129,9 @@ function Event({ event }: { event: AnalyticsEvent }) {
       ) : undefined}
       {attributes?.length ? (
         <>
-          <h4>
+          <h4 id={attributesSlug}>
             Attributes
-            <AnchorLink slug={urlify(`${eventName} Attributes`)} />
+            <AnchorLink slug={attributesSlug} />
           </h4>
           <details>
             <summary>Show attribute details</summary>
@@ -138,9 +143,9 @@ function Event({ event }: { event: AnalyticsEvent }) {
           </details>
         </>
       ) : undefined}
-      <h4>
+      <h4 id={exampleSlug}>
         Example
-        <AnchorLink slug={urlify(`${eventName} Example`)} />
+        <AnchorLink slug={exampleSlug} />
       </h4>
       <Example
         event_name={eventName}

--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -4,8 +4,9 @@ import { createPortal } from "preact/compat";
 import { useQuery } from "preact-fetching";
 import { useCurrentUser, PrivateLoginLink } from "./private";
 import { Alert } from "./components/alert";
-import { AnchorLink, urlify } from "./components/anchor-link";
+import { urlify } from "./components/anchor-link";
 import { Sidenav } from "./components/sidenav";
+import { Heading } from "./components/heading";
 
 interface AnalyticsEventAttribute {
   name: string;
@@ -102,24 +103,15 @@ function Event({ event }: { event: AnalyticsEvent }) {
     attributes = [],
   } = event;
 
-  const slug = urlify(eventName);
-  const previousEventSlug = urlify(`${eventName} Previous`);
-  const attributesSlug = urlify(`${eventName} Attributes`);
-  const exampleSlug = urlify(`${eventName} Example`);
-
   return (
     <div>
-      <h3 id={slug}>
-        {eventName}
-        <AnchorLink slug={slug} />
-      </h3>
+      <Heading level="h3">{eventName}</Heading>
       <p>{description}</p>
       {previousEventNames?.length ? (
         <>
-          <h4 id={previousEventSlug}>
+          <Heading level="h4" id={urlify(`${eventName} Previous`)}>
             Previous Event Names
-            <AnchorLink slug={previousEventSlug} />
-          </h4>
+          </Heading>
           <ul>
             {previousEventNames.map((name) => (
               <li>{name}</li>
@@ -129,10 +121,9 @@ function Event({ event }: { event: AnalyticsEvent }) {
       ) : undefined}
       {attributes?.length ? (
         <>
-          <h4 id={attributesSlug}>
+          <Heading level="h4" id={urlify(`${eventName} Attributes`)}>
             Attributes
-            <AnchorLink slug={attributesSlug} />
-          </h4>
+          </Heading>
           <details>
             <summary>Show attribute details</summary>
             <ul>
@@ -143,10 +134,9 @@ function Event({ event }: { event: AnalyticsEvent }) {
           </details>
         </>
       ) : undefined}
-      <h4 id={exampleSlug}>
+      <Heading level="h4" id={urlify(`${eventName} Example`)}>
         Example
-        <AnchorLink slug={exampleSlug} />
-      </h4>
+      </Heading>
       <Example
         event_name={eventName}
         previous_event_names={previousEventNames}

--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -201,6 +201,7 @@ function AnalyticsEvents({
   const { data, isError, error } = useQuery(
     `analyticsEvents:${eventsUrl}`,
     () =>
+      currentUser &&
       window
         .fetch(eventsUrl)
         .then((response) => response.json())

--- a/assets/js/components/anchor-link.tsx
+++ b/assets/js/components/anchor-link.tsx
@@ -26,7 +26,6 @@ export function AnchorLink({
       className="anchorjs-link"
       aria-label="Anchor"
       data-anchorjs-icon={icon}
-      id={slug}
       href={`#${slug}`}
       style={{ font: "1em / 1 anchorjs-icons", paddingLeft: "0.375em" }}
     />

--- a/assets/js/components/heading.tsx
+++ b/assets/js/components/heading.tsx
@@ -1,0 +1,27 @@
+import { h } from "preact";
+import { urlify, AnchorLink } from "./anchor-link";
+
+type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+interface HeadingProps {
+  level: HeadingLevel;
+
+  id?: string;
+
+  children: string;
+}
+
+export function Heading({
+  level,
+  children,
+  id = urlify(children),
+}: HeadingProps) {
+  const TagName = level;
+
+  return (
+    <TagName id={id}>
+      {children}
+      <AnchorLink slug={id} />
+    </TagName>
+  );
+}

--- a/assets/js/components/heading.tsx
+++ b/assets/js/components/heading.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import { urlify, AnchorLink } from "./anchor-link";
 
-type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+export type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 interface HeadingProps {
   level: HeadingLevel;

--- a/assets/js/private-articles.tsx
+++ b/assets/js/private-articles.tsx
@@ -9,7 +9,8 @@ import { useCurrentUser, PrivateLoginLink } from "./private";
 import { Alert } from "./components/alert";
 import { fetchGitHubFile, isGithubDirectory, isGithubFile } from "./github";
 import { Navigation, SidenavWithWrapper } from "./components/sidenav";
-import { AnchorLink } from "./components/anchor-link";
+import { Heading } from "./components/heading";
+import type { HeadingLevel } from "./components/heading";
 
 const GitHubContext = createContext({
   ref: undefined,
@@ -63,12 +64,12 @@ interface Frontmatter {
   category: string;
 }
 
-interface Heading {
+interface HeadingEntry {
   text: string;
   depth: number;
 }
 
-function buildNavigation(headings: Heading[]): Navigation {
+function buildNavigation(headings: HeadingEntry[]): Navigation {
   const navigation: Navigation = [];
   let lastDepth = 0;
   const stack: Navigation[] = [];
@@ -97,15 +98,11 @@ function buildNavigation(headings: Heading[]): Navigation {
   });
   return navigation;
 }
-
-type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-
-function buildHeader(Tag: HeadingTag) {
-  return ({ id, children }: { id: string; children: ComponentChildren }) => (
-    <Tag id={id}>
+function buildHeader(level: HeadingLevel) {
+  return ({ id, children }: { id: string; children: string }) => (
+    <Heading level={level} id={id}>
       {children}
-      <AnchorLink slug={id} />
-    </Tag>
+    </Heading>
   );
 }
 
@@ -167,7 +164,7 @@ function PrivateArticle({
     const [, frontMatterString, content] = atob(article.content).split("---");
     const frontMatter = loadYAML(frontMatterString) as Frontmatter;
 
-    const headings: Heading[] = [];
+    const headings: HeadingEntry[] = [];
     const headingCollector = (token: marked.Token) => {
       if (token.type === "heading") {
         headings.push({


### PR DESCRIPTION
The dynamic headings in some articles don't play well with the `:target` styling added in #308 

**Note**: This doesn't seem to work on first load, so I'm putting it in draft. I'm not 100% sure why, maybe there's a load ordering or race condition issue somewhere

| before | after |
| --- | --- |
| <img width="758" alt="Screen Shot 2022-09-26 at 1 35 40 PM" src="https://user-images.githubusercontent.com/458784/192375252-733ccb30-01a6-4cd4-b042-5fafa666abd3.png"> | <img width="758" alt="Screen Shot 2022-09-26 at 1 35 32 PM" src="https://user-images.githubusercontent.com/458784/192375268-dbb807fd-e461-4615-bbd3-cce95a1b2d20.png"> |

