### PR TITLE
Update Netlify CMS configuration for Cloud.gov Pages transition

### DIFF
--- a/_articles/github.md
+++ b/_articles/github.md
@@ -91,37 +91,37 @@ View a [list of all repositories](https://github.com/topics/login-gov) tagged fo
 
 - [**18f/identity-site**](https://github.com/18f/identity-site)<br />
   [login.gov](https://login.gov)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   Public marketing page.
 
 - [**18f/identity-style-guide**](https://github.com/18f/identity-style-guide)<br />
   [design.login.gov](https://design.login.gov)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   Walkthrough of Login.gov common styles. The respository also hosts the `identity-style-guide` npm package that contains the actual styles.
 
 - [**18f/identity-dev-docs**](https://github.com/18f/identity-dev-docs)<br />
   [developers.login.gov](https://developers.login.gov)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   Developer documentation and integration guides for OpenID Connect and SAML.
 
 - [**18f/connect.gov**](https://github.com/18F/connect.gov)<br />
   [connect.gov](https://connect.gov/)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   A site to disambiguate the Login.gov's predecessor `connect.gov` from Connecticut's ConnectCT `connect.ct.gov`
 
 - [**18f/identity-partners-site**](https://github.com/18F/identity-partners-site)<br />
   [partners.login.gov](https://partners.login.gov) <br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   A site to present information for partners
 
 - [**18f/identity-reporting**](https://github.com/18f/identity-reporting)<br />
   [data.login.gov](https://data.login.gov)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   Public reporting dashboard.
 
 - [**18f/identity-handbook**](https://github.com/18f/identity-handbook)<br />
   [handbook.login.gov](https://handbook.login.gov/)<br />
-  Hosted on: [Federalist](https://federalistapp.18f.gov/)<br />
+  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   This handbook!
 
 - [**18f/identity-handbook-private**](https://github.com/18f/identity-handbook-private) <br />

--- a/_articles/help-center-contact-form.md
+++ b/_articles/help-center-contact-form.md
@@ -21,7 +21,7 @@ before we can deploy changes on our side.
 ## Configuration
 
 To streamline working with the Salesforce team and their QA/validation process,
-we've set up our Federalist preview site to
+we've set up our Cloud.gov Pages preview site to
 
 - disable captchas
 - point at the sandbox instance

--- a/_articles/reporting-dashboard-architecture.md
+++ b/_articles/reporting-dashboard-architecture.md
@@ -28,7 +28,7 @@ This S3 bucket is exposed publicly via a CloudFront distribution.
 ### Frontend
 
 The [data.login.gov][data-login-gov] frontend, [18f/identity-reporting repo][frontend-repo],
-is served by Federalist. The code is a JavaScript-driven Single-Page App that dynamically loads
+is served by Cloud.gov Pages. The code is a JavaScript-driven Single-Page App that dynamically loads
 data from our cloudfront distro.
 
 [data-login-gov]: https://data.login.gov

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,9 +1,9 @@
 backend:
   name: github
   repo: 18f/identity-handbook
-  base_url: https://federalistapp.18f.gov
+  base_url: https://pages.cloud.gov
   auth_endpoint: external/auth/github
-  preview_context: federalist/build
+  preview_context: pages/build
   branch: main
 
   # optional

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "start": "npm run build:dev -- --watch",
     "lint": "eslint assets/js --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc",
-    "federalist": "npm run build"
+    "pages": "npm run build"
   }
 }


### PR DESCRIPTION
**Why**: [Federalist is becoming Cloud.gov Pages](https://cloud.gov/pages/federalist-migration/), and as such we'll need to update configurations accordingly.

I'm not sure of any resources for the specifics of these changes ([existing documentation](https://cloud.gov/pages/documentation/getting-started-with-netlify-cms/) still references Federalist), but these were the updates recommended directly from Cloud.gov Pages support folks.