### PR TITLE
Create deploy branch from staging

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -80,8 +80,8 @@ The release branch should be cut from code tested in staging and it should be th
 
 ```bash
 cd identity-$REPO
-git checkout main
-git pull
+git fetch
+git checkout $(curl --silent https://idp.staging.login.gov/api/deploy.json | jq -r .git_sha)
 git checkout -b stages/rc-2020-06-17 # CHANGE THIS DATE
 git push -u origin HEAD
 ```
@@ -120,8 +120,7 @@ create a git commit with an explicit merge strategy to "true-up" with the `main`
 
 ```bash
 cd identity-$REPO
-git checkout main && git fetch && git pull
-git checkout -b stages/rc-2020-06-17 # CHANGE THIS DATE
+git checkout stages/rc-2020-06-17 # CHANGE THIS DATE
 git merge -s ours origin/stages/prod # custom merge strategy
 git push -u origin HEAD
 ```


### PR DESCRIPTION
**Why**: For consistency with the rest of the documentation which instructs the deployer to both "test the proofing flow in staging" and "cut a release from the code that is deployed to staging".

This had previously been changed in #267, where at the time we were still deploying several days after the deploy branch had been cut and therefore it was assumed that staging would contain at least those changes by the time that the weekly deploy would occur. This is no longer the case.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1666636952839999?thread_ts=1666632234.792629&cid=C0NGESUN5