### PR TITLE
Add "Cloud.gov Pages" article for static site / Netlify CMS access

### DIFF
--- a/_articles/cloud-gov-pages.md
+++ b/_articles/cloud-gov-pages.md
@@ -11,8 +11,8 @@ subcategory: Code
 Login.gov uses [Cloud.gov Pages][cloud-gov-pages] as its hosting provider for our [static sites][static-sites]. By becoming a user of the Login.gov organization in Cloud.gov Pages, you'll have access to build logs and settings configuration for each of our sites. Organization access also allows you to log in on sites which use Netlify CMS ([including this handbook!][handbook-admin]).
 
 [cloud-gov-pages]: https://cloud.gov/pages/
-[static-sites]: https://handbook.login.gov/articles/github.html#static-sites
-[handbook-admin]: https://handbook.login.gov/admin/
+[static-sites]: {% link _articles/github.md %}#static-sites
+[handbook-admin]: {{ site.baseurl }}/admin/
 
 ## Requesting Access to Cloud.gov Pages
 

--- a/_articles/cloud-gov-pages.md
+++ b/_articles/cloud-gov-pages.md
@@ -1,0 +1,25 @@
+---
+title: Cloud.gov Pages
+layout: article
+description: Overview of static site hosting and authentication
+category: Development
+subcategory: Code
+---
+
+## Overview
+
+Login.gov uses [Cloud.gov Pages][cloud-gov-pages] as its hosting provider for our [static sites][static-sites]. By becoming a user of the Login.gov organization in Cloud.gov Pages, you'll have access to build logs and settings configuration for each of our sites. Organization access also allows you to log in on sites which use Netlify CMS ([including this handbook!][handbook-admin]).
+
+[cloud-gov-pages]: https://cloud.gov/pages/
+[static-sites]: https://handbook.login.gov/articles/github.html#static-sites
+[handbook-admin]: https://handbook.login.gov/admin/
+
+## Requesting Access to Cloud.gov Pages
+
+**For those requesting access:** Reach out to any of the organization managers listed in the [Handbook Appendix][handbook-appendix-cloud-gov]. After you have been added to the organization, you will need to [sign in to the Cloud.gov Pages dashboard with GSA.gov][cloud-gov-pages-login] _before_ authenticating with Netlify CMS.
+
+**For managers granting access:** [Sign in to the Cloud.gov Pages dashboard with GSA.gov][cloud-gov-pages-login], then add a new member under the "Add user" option of the [Login.gov Organization][cloud-gov-login-gov-org]
+
+[handbook-appendix-cloud-gov]: https://docs.google.com/document/d/1ZMpi7Gj-Og1dn-qUBfQHqLc1Im7rUzDmIxKn11DPJzk/edit#heading=h.80vseiuz6587
+[cloud-gov-pages-login]: https://pages.cloud.gov/login
+[cloud-gov-login-gov-org]: https://pages.cloud.gov/organizations/16


### PR DESCRIPTION
**Why**: To be able to link as a resource for users seeking access to Netlify CMS, and for other organization managers to help administrate the organization.

**Live preview:** https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/aduth-cloud-gov-pages/articles/cloud-gov-pages.html