### PR TITLE
Fix capitalization typo in vendor outage page

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -9,8 +9,8 @@ If an outage in a 3rd party vendor is identified, we can manually update the con
 
 Currently, this is available for the following vendors:
 - `vendor_status_acuant`
-- `vendor_status_lexisNexis_instantverify`
-- `vendor_status_lexisNexis_trueid`
+- `vendor_status_lexisnexis_instantverify`
+- `vendor_status_lexisnexis_trueid`
 - `vendor_status_sms`
 - `vendor_status_voice`
 


### PR DESCRIPTION
The actual configs are lowercased: https://github.com/18F/identity-idp/blob/6acbb307b3e37b6f4cf5478223c92016487971d6/lib/identity_config.rb#L287-L288

These configs are case-sensitive so the handbook page was cruising for a bruising