### PR TITLE
Add bundle exec clarification to bin/scp-s3 instructions

### DIFF
--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -138,11 +138,14 @@ The script can output as new-line delimited JSON (`--json`) or as a CSV (`--csv`
 ## `scp-s3`
 
 Imitates `scp` by copying a file in and out of S3. Use the instance ID to refer to remote hosts
-(see [`ls-servers`](#ls-servers) to find them). **You must be on the VPN for this script to work**
+(see [`ls-servers`](#ls-servers) to find them). **You must be on the VPN for this script to work.**
+
+**Also note that currently you must prepend the script with `bundle exec` in
+order for it to work due to a [known bug](https://github.com/18F/identity-devops/pull/5789).**
 
 ```bash
 aws-vault exec sandbox-power --
-    ./bin/scp-s3 i-abcdef1234:/tmp/file.txt ./file.txt
+    bundle exec ./bin/scp-s3 i-abcdef1234:/tmp/file.txt ./file.txt
 ```
 
 ## `ssm-instance`


### PR DESCRIPTION
Should be reverted whenever https://github.com/18F/identity-devops/pull/5789 is fixed.