### PR TITLE
Mark sprint teams that are not active as archived

### DIFF
--- a/_articles/sprint-teams.md
+++ b/_articles/sprint-teams.md
@@ -15,7 +15,12 @@ see data/sprint_teams.yml for the data
 {% assign sprint_teams = site.data.sprint_teams | sort: "name" %}
 
 {% for sprint_team in sprint_teams %}
+<div markdown="1" class="{% if sprint_team.archived %}sprint-team--archived{% endif %}">
 ## {{ sprint_team.name }}
+
+{% if sprint_team.archived %}
+This sprint team is not currently active
+{% endif %}
 
 {% if sprint_team.namesake_markdown -%}
 * **Namesake**: {{ sprint_team.namesake_markdown }}
@@ -27,5 +32,5 @@ see data/sprint_teams.yml for the data
 {% if sprint_team.readme -%}
 * **Readme**: [View Team {{sprint_team.name}} Readme]({{ sprint_team.readme }})
 {%- endif %}
-
+</div>
 {% endfor %}

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -20,6 +20,7 @@
   slack_channel_url: https://gsa-tts.slack.com/archives/C0184P9SCJ0
   slack_group_name: login-grace
   readme: https://docs.google.com/document/d/1x_IPoYc_kavE6Rw58leIckp85Js7fKPy_NebpqC3iN0/edit
+  archived: true
 
 - name: IDVA
   focus_area: "Equity Study & API"
@@ -73,6 +74,7 @@
   focus_area: Inherited Proofing
   slack_channel_url: https://gsa-tts.slack.com/archives/C03JDA5HNUV
   slack_channel_name: login-team-ross
+  archived: true
 
 - name: Ursula
   namesake_markdown: "[Ursula Burns](https://en.wikipedia.org/wiki/Ursula_Burns), who has been CEO of technology companies like Xerox"

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,6 +39,10 @@
   color: gray;
 }
 
+.sprint-team--archived {
+  color: gray;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Grays out teams and adds a lil note:

| example |
| --- |
| <img width="658" alt="Screen Shot 2023-02-17 at 11 20 04 AM" src="https://user-images.githubusercontent.com/458784/219767063-d2a01052-17f8-43a9-aac0-b45735b63210.png"> |

