### PR TITLE
Swapping passenger-restart for asg-recycle

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -32,7 +32,8 @@ the `stages/prod` branch.
 | **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Twice a week | [@login-deployer][deployer-rotation] |
 | **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | [@login-deployer][deployer-rotation], or engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
-| **Config Recyle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
+| **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger_restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
+| **Config Recycle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
 
 [deployer-rotation]: {% link _articles/appdev-deploy-rotation.md %}
 
@@ -252,6 +253,20 @@ aws-vault exec prod-power -- ./bin/scale-remove-new-instances prod worker
    ahold of [somebody with admin merge permissions](https://docs.google.com/document/d/1ZMpi7Gj-Og1dn-qUBfQHqLc1Im7rUzDmIxKn11DPJzk/edit#heading=h.dm83ewdwp8o) who can override waiting for CI to finish
 
 1. Recycle the app to get the new code out there (follow the [Production Deploy steps](#production))
+
+### Passenger restart
+A passenger restart is a quicker way to pick up changes to configuration in S3 without the need
+to scale up new instances.
+
+1. Make the config changes
+
+1. Run the passenger restart command for the environment from the identity-devops repository
+   ```bash
+   # Restart passenger on the IDP instances
+   aws-vault exec prod-power -- bin/ssm-command -d passenger-restart -o -r idp -e prod
+   ```
+
+1. Check out [passenger-restart](https://github.com/18F/identity-devops/wiki/Troubleshooting-Quick-Reference#passenger-restart) for more information on what the command can do
 
 ### Config Recycle
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -32,7 +32,7 @@ the `stages/prod` branch.
 | **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Twice a week | [@login-deployer][deployer-rotation] |
 | **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | [@login-deployer][deployer-rotation], or engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
-| **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger_restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
+| **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
 | **Config Recycle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
 
 [deployer-rotation]: {% link _articles/appdev-deploy-rotation.md %}
@@ -256,7 +256,7 @@ aws-vault exec prod-power -- ./bin/scale-remove-new-instances prod worker
 
 ### Passenger restart
 A passenger restart is a quicker way to pick up changes to configuration in S3 without the need
-to scale up new instances.
+to scale up new instances. Check out [passenger-restart](https://github.com/18F/identity-devops/wiki/Troubleshooting-Quick-Reference#passenger-restart) for more information on what the command can do
 
 1. Make the config changes
 
@@ -266,7 +266,6 @@ to scale up new instances.
    aws-vault exec prod-power -- bin/ssm-command -d passenger-restart -o -r idp -e prod
    ```
 
-1. Check out [passenger-restart](https://github.com/18F/identity-devops/wiki/Troubleshooting-Quick-Reference#passenger-restart) for more information on what the command can do
 
 ### Config Recycle
 

--- a/_articles/appdev-secrets-configuration.md
+++ b/_articles/appdev-secrets-configuration.md
@@ -18,7 +18,7 @@ environment by merging default values with an environment-specific YAML file.
 * In deployed environments, this file is downloaded from S3 when activating or deploying an instance
   (see [`deploy/activate`][deploy-activate] and the [`activate.rb`][download-from-s3]).
 
-**Changing configuration for a deployed application [requires a recycle][recycle-config]**, since
+**Changing configuration for a deployed application [requires a passenger restart][passenger-restart]**, since
 this merge step only happens at activation.
 
 The S3 buckets that contain secrets are versioned, so we can recover old versions
@@ -30,7 +30,7 @@ machine when done.
 
 [deploy-activate]: https://github.com/18F/identity-idp/blob/main/deploy/activate
 [download-from-s3]: https://github.com/18F/identity-idp/blob/a95fd33d24c6761818993cfbc334a28986783034/lib/deploy/activate.rb#L93-L97
-[recycle-config]: {% link _articles/appdev-deploy.md %}#config-recycle
+[passenger-restart]: {% link _articles/appdev-deploy.md %}#passenger-restart
 
 ## Using `app-s3-secret`
 

--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -55,10 +55,10 @@ app-s3-secret: Upload changes to S3? (y/n)
 y
 ```
 
-After updating, [recycle the app][config-recycle] so it creates new instances that will download
-this updated config.
+After updating, [restart_passenger][passenger-restart] so that passenger is restarted and will download
+this updated config without needing to stand up new instances.
 
-[config-recycle]: {% link _articles/appdev-deploy.md %}#config-recycle
+[passenger-restart]: {% link _articles/appdev-deploy.md %}#passenger-restart
 
 ### Looking at Changes to Secrets
 
@@ -243,14 +243,6 @@ aws-vault exec sandbox-power --
 ```
 
 ### `passenger-restart`
-
-{%- capture alert_content -%}
-2022-01-04: This script is **not safe** to use at this time, it drops live requests instead
-of rotating smoothly. See [identity-devops#/5651](https://github.com/18F/identity-devops/issues/5651)
-for more information.
-{%- endcapture -%}
-
-{% include alert.html content=alert_content alert_class="usa-alert--error" %}
 
 "Safely" restart the NGINX/Passenger service which reloads `application.yml` from
 S3.

--- a/_articles/partnerships-test-ssns.md
+++ b/_articles/partnerships-test-ssns.md
@@ -31,10 +31,10 @@ This should open the `application.yml` file for the sandbox IdP in your text edi
   test_ssn_allowed_list: '111223333,444556666,777889999'
 ```
 
-Save and quit your text editor and confirm that the diff looks correct to save the file. The changes will take effect when the sandbox environment recycles, which happens automatically most weekdays. If the change needs to take effect immediately, you can recycle the sandbox manually:
+Save and quit your text editor and confirm that the diff looks correct to save the file. The changes will take effect when the sandbox environment recycles, which happens automatically most weekdays. If the change needs to take effect immediately, you can restart passenger in the sandbox manually:
 
 ```sh
-bin/awsv sandbox bin/asg-recycle int idp
+bin/awsv sandbox bin/ssm-command -d passenger-restart -o -r idp -e int
 ```
 
 [^1]: See our [dev docs](https://developers.login.gov/testing/#personal-information-verification) for more information on this restriction.

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -23,6 +23,6 @@ The default value is `operational`, set in `config/application.yml.default`
 
 To do the configuration change, edit the configuration (per the [guidance here]({% link _articles/appdev-secrets-configuration.md %}).
 
-Once the recycle completes, users in affected flows will be presented with an error message explaining the outage, or redirected to an error page if they are unable to continue.
+Once the restart completes, users in affected flows will be presented with an error message explaining the outage, or redirected to an error page if they are unable to continue.
 
 Once we have received word that the vendor is back up and running, simply re-edit the configuration to delete the vendor status, or explicitly set it to `operational`.


### PR DESCRIPTION
## Summary
Adds instructions for using the new passenger restart ssm document. This was swapped in for the asg-recycle command when all that was changing was a value in application.yml. The new ssm document is much faster than our typical environment recycle and doesn't require any scale up/down of instances in an environment. This is [safe to use in production](https://github.com/18F/identity-devops/issues/5651) as it uses the passenger-config restart-app command instead of restarting the entire service, preventing it from dropping connections during the restart.