### PR TITLE
Upgrade html-proofer to drop nokogumbo dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'activesupport', '~> 7.0.4'
-  gem 'html-proofer', '~> 3.15.3'
+  gem 'html-proofer', '~> 4.4.3'
   gem 'nokogiri', '~> 1.13.10'
   gem 'rspec', '~> 3.9.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,19 +14,20 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    html-proofer (3.15.3)
+    html-proofer (4.4.3)
       addressable (~> 2.3)
       mercenary (~> 0.3)
-      nokogumbo (~> 2.0)
-      parallel (~> 1.3)
+      nokogiri (~> 1.13)
+      parallel (~> 1.10)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -70,8 +71,6 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogumbo (2.0.5)
-      nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -108,13 +107,14 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
     yell (2.2.2)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (~> 7.0.4)
-  html-proofer (~> 3.15.3)
+  html-proofer (~> 4.4.3)
   jekyll (~> 4)
   jekyll-environment-variables
   jekyll-last-modified-at

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ spellcheck:
 
 test: build
 	bundle exec rspec spec
-	bundle exec htmlproofer --disable-external --allow-hash-href `pwd`/_site
+	bundle exec htmlproofer --disable-external --allow-hash-href --allow-missing-href=true --enforce-https=false `pwd`/_site
 
 clean:
 	rm -rf _site

--- a/_articles/glossary.md
+++ b/_articles/glossary.md
@@ -60,7 +60,7 @@ A privacy architecture that allows the [IdP](#idp) and [RP](#rp) to collaborate 
 ### (Triple) Blind Privacy
 A privacy architecture that includes the [Double Blind Privacy](#double-blind-privacy) model, with the addition of the [Hub](#hub) having zero disclosure  to User’s [PII](#pii).
 
-Source: [Privacy By Design](https://www.ipc.on.ca/images/Resources/operationalizing-pbd-guide.pdf), [SecureKey](http://securekey.com/wp-content/uploads/2015/09/SK-UN117-Trust-Framework-SecureKey-Concierge-Canada.pdf)
+Source: [Privacy By Design](https://www.ipc.on.ca/images/Resources/operationalizing-pbd-guide.pdf), [SecureKey](https://securekey.com/wp-content/uploads/2015/09/SK-UN117-Trust-Framework-SecureKey-Concierge-Canada.pdf)
 
 ### CCN
 
@@ -69,23 +69,23 @@ Source: [Privacy By Design](https://www.ipc.on.ca/images/Resources/operationaliz
 ### Credential
 An object or data structure that authoritatively binds an identity (and optionally, additional attributes) to a token possessed and controlled by a Subscriber.
 
-Source: [SP 800-63](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf)
+Source: [SP 800-63](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf)
 
 Evidence attesting to one’s right to credit or authority.
 
-Source: [FIPS 201](http://csrc.nist.gov/publications/fips/fips201-1/FIPS-201-1-chng1.pdf)
+Source: [FIPS 201](https://csrc.nist.gov/publications/fips/fips201-1/FIPS-201-1-chng1.pdf)
 
-Evidence or testimonials that support a claim of identity or assertion of an attribute and 
+Evidence or testimonials that support a claim of identity or assertion of an attribute and
 are intended to be used more than once.
 
-Source: [CNSSI-4009](http://www.ncsc.gov/nittf/docs/CNSSI-4009_National_Information_Assurance.pdf), [Searchable Source](http://www.fismapedia.org/index.php/Category:CNSSI_4009_Terms)
+Source: [CNSSI-4009](https://www.ncsc.gov/nittf/docs/CNSSI-4009_National_Information_Assurance.pdf), [Searchable Source](http://www.fismapedia.org/index.php/Category:CNSSI_4009_Terms)
 
 ### CSP
 **Credential Service Provider**
 
 A trusted entity that issues or registers Subscriber tokens and issues electronic credentials to Subscribers. The CSP may encompass [Registration Authorities (RAs)](#ra) and [Verifiers](#verifier) that it operates. A CSP may be an independent third party, or may issue credentials for its own use.
 
-Source: [SP 800-63](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf)
+Source: [SP 800-63](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-2.pdf)
 
 A CSP is often also an [IdP](#idp).
 
@@ -94,7 +94,7 @@ Documents that indicate that the holder is eligible for a service or benefit, su
 
 A set of rules, defined by the IT resource owner, for managing access to a resource (asset, service, or entity) and for what purpose.  A User's level of access is conditioned not only by your identity but is also likely to be constrained by a number of further security considerations.
 
-Source: [Entities and Entitlement](http://blog.opengroup.org/2012/08/07/entities-and-entitlement-the-bigger-picture-of-identity-management/)
+Source: [Entities and Entitlement](https://blog.opengroup.org/2012/08/07/entities-and-entitlement-the-bigger-picture-of-identity-management/)
 
 ### Factor
 A factor is a type of evidence that users can provide to prove they own an identity record or an account. There are three types of factors:
@@ -205,7 +205,7 @@ Level of Assurance describes the degree of confidence in the vetting processes r
 - Three Party Model: User, Identity Provider and Service Provider
 - Four Party model: User, Identity Provider, Attribute Provider and Service Provider
 
-Source: [NISTIR 7817](http://nvlpubs.nist.gov/nistpubs/ir/2012/NIST.IR.7817.pdf)
+Source: [NISTIR 7817](https://nvlpubs.nist.gov/nistpubs/ir/2012/NIST.IR.7817.pdf)
 
 ### MFA
 **Multi-factor Authentication**
@@ -219,7 +219,7 @@ An identity record present in the database that is missing one or more of the at
 ### OTP
 **One-time password**
 Token valid for one use. This token can be alphanumeric (using letters and numbers) or numeric (using only numbers). See https://en.wikipedia.org/wiki/One-time_password
-* Use **"one-time code"** to refer to any (numeric or alphanumeric) OTP sent to confirm device ownership. Never use *one-time password*, *OTP*, or *TOTP* in the interface. 
+* Use **"one-time code"** to refer to any (numeric or alphanumeric) OTP sent to confirm device ownership. Never use *one-time password*, *OTP*, or *TOTP* in the interface.
 
 
 ### Passcode
@@ -242,7 +242,7 @@ We prefer Service Provider to Relying Party when describing client applications.
 
 An entity that relies upon the subscriber’s credentials, typically to process a transaction or grant access to information or a system.
 
-Source: [CNSSI-4009](http://www.ncsc.gov/nittf/docs/CNSSI-4009_National_Information_Assurance.pdf), [Searchable Source](http://www.fismapedia.org/index.php/Category:CNSSI_4009_Terms)
+Source: [CNSSI-4009](https://www.ncsc.gov/nittf/docs/CNSSI-4009_National_Information_Assurance.pdf), [Searchable Source](http://www.fismapedia.org/index.php/Category:CNSSI_4009_Terms)
 
 An entity that relies upon the Subscriber's token and credentials or a Verifier's assertion of a Claimant’s identity, typically to process a transaction or grant access to information or a system. Source: SP 800-63
 

--- a/_articles/openssl-recipes.md
+++ b/_articles/openssl-recipes.md
@@ -78,12 +78,12 @@ Certificate:
         X509v3 extensions:
             X509v3 Basic Constraints: critical
                 CA:TRUE
-            Authority Information Access: 
-                CA Issuers - URI:http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c
+            Authority Information Access:
+                CA Issuers - URI:https://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c
 
-            X509v3 Policy Mappings: 
+            X509v3 Policy Mappings:
                 2.16.840.1.101.3.2.1.3.6:2.16.840.1.101.3.2.1.3.3, 2.16.840.1.101.3.2.1.3.7:2.16.840.1.101.3.2.1.3.12, 2.16.840.1.101.3.2.1.3.16:2.16.840.1.101.3.2.1.3.4, 2.16.840.1.101.3.2.1.3.8:2.16.840.1.101.3.2.1.3.37, 2.16.840.1.101.3.2.1.3.36:2.16.840.1.101.3.2.1.3.38
-            X509v3 Certificate Policies: 
+            X509v3 Certificate Policies:
                 Policy: 2.16.840.1.101.3.2.1.3.6
                 Policy: 2.16.840.1.101.3.2.1.3.7
                 Policy: 2.16.840.1.101.3.2.1.3.8
@@ -102,8 +102,8 @@ Certificate:
                 Policy: 2.16.840.1.101.3.2.1.3.40
                 Policy: 2.16.840.1.101.3.2.1.3.41
 
-            Subject Information Access: 
-                CA Repository - URI:http://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
+            Subject Information Access:
+                CA Repository - URI:https://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
 
             X509v3 Policy Constraints: critical
                 Require Explicit Policy:0, Inhibit Policy Mapping:2
@@ -111,15 +111,15 @@ Certificate:
                 0
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
-            X509v3 Authority Key Identifier: 
+            X509v3 Authority Key Identifier:
                 keyid:AD:0C:7A:75:5C:E5:F3:98:C4:79:98:0E:AC:28:FD:97:F4:E7:02:FC
 
-            X509v3 CRL Distribution Points: 
+            X509v3 CRL Distribution Points:
 
                 Full Name:
-                  URI:http://http.fpki.gov/fcpca/fcpca.crl
+                  URI:https://http.fpki.gov/fcpca/fcpca.crl
 
-            X509v3 Subject Key Identifier: 
+            X509v3 Subject Key Identifier:
                 79:F0:00:49:EB:7F:77:C2:5D:41:02:65:34:8A:90:23:9B:1E:07:6F
     Signature Algorithm: sha256WithRSAEncryption
          1b:bf:d1:54:a9:14:90:78:96:c4:73:63:79:ea:4b:95:75:87:

--- a/_articles/openssl-recipes.md
+++ b/_articles/openssl-recipes.md
@@ -79,7 +79,7 @@ Certificate:
             X509v3 Basic Constraints: critical
                 CA:TRUE
             Authority Information Access:
-                CA Issuers - URI:https://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c
+                CA Issuers - URI:http://http.fpki.gov/fcpca/caCertsIssuedTofcpca.p7c
 
             X509v3 Policy Mappings:
                 2.16.840.1.101.3.2.1.3.6:2.16.840.1.101.3.2.1.3.3, 2.16.840.1.101.3.2.1.3.7:2.16.840.1.101.3.2.1.3.12, 2.16.840.1.101.3.2.1.3.16:2.16.840.1.101.3.2.1.3.4, 2.16.840.1.101.3.2.1.3.8:2.16.840.1.101.3.2.1.3.37, 2.16.840.1.101.3.2.1.3.36:2.16.840.1.101.3.2.1.3.38
@@ -103,7 +103,7 @@ Certificate:
                 Policy: 2.16.840.1.101.3.2.1.3.41
 
             Subject Information Access:
-                CA Repository - URI:https://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
+                CA Repository - URI:http://repo.fpki.gov/bridge/caCertsIssuedByfbcag4.p7c
 
             X509v3 Policy Constraints: critical
                 Require Explicit Policy:0, Inhibit Policy Mapping:2
@@ -117,7 +117,7 @@ Certificate:
             X509v3 CRL Distribution Points:
 
                 Full Name:
-                  URI:https://http.fpki.gov/fcpca/fcpca.crl
+                  URI:http://http.fpki.gov/fcpca/fcpca.crl
 
             X509v3 Subject Key Identifier:
                 79:F0:00:49:EB:7F:77:C2:5D:41:02:65:34:8A:90:23:9B:1E:07:6F

--- a/_articles/piv-ssh.md
+++ b/_articles/piv-ssh.md
@@ -42,7 +42,7 @@ If you plug your PIV into your mac and see a dialog that looks like this, *do no
 This will not affect devops things, however it will bind your MacOS local user identity with the smart card credential, so when the PIV is in the reader, you will have to enter the PIN to complete authentication.
 
 ## References
-- <http://security.stackexchange.com/questions/104293/use-hspd-12-piv-keys-for-ssh>
+- <https://security.stackexchange.com/questions/104293/use-hspd-12-piv-keys-for-ssh>
 - <https://developers.yubico.com/yubico-piv-tool/SSH_with_PIV_and_PKCS11.html>
 - <https://ludovicrousseau.blogspot.com/2014/03/level-1-smart-card-support-on-mac-os-x.html>
 - <https://resources.jamf.com/documents/technical-papers/macos-smart-card-overview.pdf>

--- a/_articles/platform-gitlab.md
+++ b/_articles/platform-gitlab.md
@@ -124,7 +124,7 @@ openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out pub
 1. Grab the IDP sandbox signing certificate from <https://developers.login.gov/saml/> and get its fingerprint:
 ```
 curl -s https://idp.int.identitysandbox.gov/api/saml/metadata2021 \
-| xml sel -N x="https://www.w3.org/2000/09/xmldsig#" -t -v '(//x:X509Certificate)[1]' \
+| xml sel -N x="http://www.w3.org/2000/09/xmldsig#" -t -v '(//x:X509Certificate)[1]' \
 | sed '1i\
 -----BEGIN CERTIFICATE-----
 ' \

--- a/_articles/platform-gitlab.md
+++ b/_articles/platform-gitlab.md
@@ -124,7 +124,7 @@ openssl req -nodes -x509 -days 365 -newkey rsa:2048 -keyout private.pem -out pub
 1. Grab the IDP sandbox signing certificate from <https://developers.login.gov/saml/> and get its fingerprint:
 ```
 curl -s https://idp.int.identitysandbox.gov/api/saml/metadata2021 \
-| xml sel -N x="http://www.w3.org/2000/09/xmldsig#" -t -v '(//x:X509Certificate)[1]' \
+| xml sel -N x="https://www.w3.org/2000/09/xmldsig#" -t -v '(//x:X509Certificate)[1]' \
 | sed '1i\
 -----BEGIN CERTIFICATE-----
 ' \
@@ -142,7 +142,7 @@ aws s3 cp - "s3://${SECRET_BUCKET}/alpha/saml_private_key" --no-guess-mime-type 
     [...]
 ```
 
-1. With the public cert generated above, and replacing `$ENVIRONMENT`, configure a test integration at http://dashboard.int.identitysandbox.gov with the following parameters:
+1. With the public cert generated above, and replacing `$ENVIRONMENT`, configure a test integration at https://dashboard.int.identitysandbox.gov with the following parameters:
   - Issuer: `urn:gov:gsa:openidconnect.profiles:sp:sso:login_gov:gitlab_$ENVIRONMENT`
   - Return to App URL: `'https://gitlab.$ENVIRONMENT.gitlab.identitysandbox.gov'`
   - Level of Service:  `Authentication Only` (*Formerly labeled `IAL1`)

--- a/_articles/saml.md
+++ b/_articles/saml.md
@@ -54,8 +54,8 @@ This is usually caused by a mismatch between the IdP certificate used to sign th
 To fix this, grab the certificate from the response, e.g.,
 
 ```
-<KeyInfo 
-    xmlns="http://www.w3.org/2000/09/xmldsig#">
+<KeyInfo
+    xmlns="https://www.w3.org/2000/09/xmldsig#">
     <ds:X509Data>
         <ds:X509Certificate>
         MII/KeepCopyingButBreakItUpInto64CharacterLinesWhenYouSaveItHere...TheLastLineMayNotBeExactly64CharactersAndThatsOK=
@@ -63,7 +63,7 @@ To fix this, grab the certificate from the response, e.g.,
     </ds:X509Data>
 </KeyInfo>
 ```
-edit it to look like a normal certificate (or find the orig), e.g., 
+edit it to look like a normal certificate (or find the orig), e.g.,
 ```
 -----BEGIN CERTIFICATE-----
 MII/KeepCopyingButBreakItUpInto64CharacterLinesWhenYouSaveItHere

--- a/_articles/saml.md
+++ b/_articles/saml.md
@@ -55,7 +55,7 @@ To fix this, grab the certificate from the response, e.g.,
 
 ```
 <KeyInfo
-    xmlns="https://www.w3.org/2000/09/xmldsig#">
+    xmlns="http://www.w3.org/2000/09/xmldsig#">
     <ds:X509Data>
         <ds:X509Certificate>
         MII/KeepCopyingButBreakItUpInto64CharacterLinesWhenYouSaveItHere...TheLastLineMayNotBeExactly64CharactersAndThatsOK=

--- a/_articles/secops-incident-response-guide.md
+++ b/_articles/secops-incident-response-guide.md
@@ -128,7 +128,7 @@ For full details, read on.
 
 ### Initiate Phase
 
-An incident begins when someone becomes aware of a potential incident. We define “incident” broadly, following [NIST SP 800-61](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as “a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices” (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of Login.gov.
+An incident begins when someone becomes aware of a potential incident. We define “incident” broadly, following [NIST SP 800-61](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as “a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices” (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of Login.gov.
 
 When a person outside the Login.gov team (the reporter) notices a Login.gov-related incident, they should begin reporting it by using the 18F incident response process (need link here), and then post about it in #login-situation. If they don’t get acknowledgment from the Login.gov team right away, they should escalate by contacting the Login.gov leads directly until they receive acknowledgment of their report.
 
@@ -247,7 +247,7 @@ The final step in handling a security incident is figuring out what we learned. 
 
 Conducting retrospectives is out of the scope of this document, but as a crash course, here’s an [introduction to blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/). We follow the basic steps listed at [login-gov-postmortems](https://drive.google.com/open?id=1A9y94VgHPOcaCCTdGRh0aWINOrBjUwo2ZepzBlTM--8).
 
-The report should contain a timeline of the incident, details about how the incident progressed, and information about the vulnerabilities that led to the incident. A cause analysis is an important part of this report; the team should use tools such as [Infinite Hows](http://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) and [Five Whys](https://en.wikipedia.org/wiki/5_Whys) to try to dig into causes, how future incidents could be prevented, how responses could be better in the future, etc.
+The report should contain a timeline of the incident, details about how the incident progressed, and information about the vulnerabilities that led to the incident. A cause analysis is an important part of this report; the team should use tools such as [Infinite Hows](https://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) and [Five Whys](https://en.wikipedia.org/wiki/5_Whys) to try to dig into causes, how future incidents could be prevented, how responses could be better in the future, etc.
 
 The report should also contain some basic response metrics:
 * Discovery method (how did we become aware of the issue?)
@@ -399,8 +399,8 @@ Anyone with access to production, including:
 
 ### Why do I need to participate in contingency planning exercises (wargames) and IR Fire Drills?
 
-* **Resources** - It takes a full team to respond, and every participant is important! 
+* **Resources** - It takes a full team to respond, and every participant is important!
 * **Readiness** - Only through practice will we be and remain ready to meet the challenges Login.gov faces
 * **Refinement** - Only through participating fully can we refine our processes to improve response and efficiency
 * **Required** - GSA authorizes Login.gov to operate, in part on the understanding that we will adhere to [GSA IT - IT Security Procedural Guide: Incident Response](https://www.gsa.gov/cdnstatic/Incident_Response_%5BCIO_IT_Security_01-02_Rev_18%5D_03-26-2021docx.pdf)
-* **Regulation (Law)** - Per FISMA we must follow [NIST 800-61r2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) - Computer Security Incident Handling Guide
+* **Regulation (Law)** - Per FISMA we must follow [NIST 800-61r2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) - Computer Security Incident Handling Guide

--- a/_articles/toubleshooting-expiring-pivcac.md
+++ b/_articles/toubleshooting-expiring-pivcac.md
@@ -93,13 +93,13 @@ Look for the following in the output:
 
 ```
 Subject Information Access:
-    CA Repository - URI:http://pki.treasury.gov/root_sia.p7c
+    CA Repository - URI:https://pki.treasury.gov/root_sia.p7c
 ```
 
 Next, download the p7c bundle for the repository:
 
 ```shell
-curl http://pki.treasury.gov/root_sia.p7c -o tmp/bundle.p7c
+curl https://pki.treasury.gov/root_sia.p7c -o tmp/bundle.p7c
 ```
 
 Finally, read in the certificates from the bundle and look for a replacement:

--- a/_articles/toubleshooting-expiring-pivcac.md
+++ b/_articles/toubleshooting-expiring-pivcac.md
@@ -93,13 +93,13 @@ Look for the following in the output:
 
 ```
 Subject Information Access:
-    CA Repository - URI:https://pki.treasury.gov/root_sia.p7c
+    CA Repository - URI:http://pki.treasury.gov/root_sia.p7c
 ```
 
 Next, download the p7c bundle for the repository:
 
 ```shell
-curl https://pki.treasury.gov/root_sia.p7c -o tmp/bundle.p7c
+curl http://pki.treasury.gov/root_sia.p7c -o tmp/bundle.p7c
 ```
 
 Finally, read in the certificates from the bundle and look for a replacement:

--- a/_articles/troubleshooting-pivcacs.md
+++ b/_articles/troubleshooting-pivcacs.md
@@ -73,8 +73,8 @@ and how to add it.
     key_id: 8C:D6:D4:69:A9:E4:85:41:3A:6A:A6:5E:DA:51:1A:17:8D:92:8B:6C
     signing_key_id: CC:00:68:61:A6:A5:03:93:10:0A:1B:61:B7:87:18:C1:45:56:DA:82
     ca_issuer_dn: /DC=sbu/DC=state/CN=Configuration/CN=Services/CN=Public Key Services/CN=AIA/CN=U.S. Department of State AD Root CA
-    ca_issuer_url: https://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
-    fetching: https://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
+    ca_issuer_url: http://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
+    fetching: http://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
     ///////////////////////////////////////
 
    ```

--- a/_articles/troubleshooting-pivcacs.md
+++ b/_articles/troubleshooting-pivcacs.md
@@ -73,8 +73,8 @@ and how to add it.
     key_id: 8C:D6:D4:69:A9:E4:85:41:3A:6A:A6:5E:DA:51:1A:17:8D:92:8B:6C
     signing_key_id: CC:00:68:61:A6:A5:03:93:10:0A:1B:61:B7:87:18:C1:45:56:DA:82
     ca_issuer_dn: /DC=sbu/DC=state/CN=Configuration/CN=Services/CN=Public Key Services/CN=AIA/CN=U.S. Department of State AD Root CA
-    ca_issuer_url: http://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
-    fetching: http://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
+    ca_issuer_url: https://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
+    fetching: https://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
     ///////////////////////////////////////
 
    ```
@@ -118,9 +118,9 @@ and how to add it.
         => #<Certificate:0x00007fd564fa89a8 ...>
         ```
     1. Test that the end-user certificate is now valid by running `rake certs:validate_client_cert[path/to/cert.pem]`
-        
+
         The script will print whether the certificate is now valid.
-        
+
         ```shell
         Certificate is valid!
         ```

--- a/_articles/windows-virtual-machine.md
+++ b/_articles/windows-virtual-machine.md
@@ -46,12 +46,3 @@ subcategory: "Setup"
 In a Windows virtual machine, the host machine can be resolved at the IP address `10.0.2.2` with VirtualBox's default network settings. Many applications will bind only to `localhost`. Refer to the project's documentation for more information about how to bind to other addresses. Typically, this can be done by passing the host as an environment variable (e.g. `HOST=10.0.2.2 make run`).
 
 For the IDP, see: ["Testing on a mobile device or in a virtual machine"](https://github.com/18F/identity-idp#testing-on-a-mobile-device-or-in-a-virtual-machine)
-
-## Set up JAWS Screen Reader
-
-For windows 10, I (Aaron) needed to make the following adjustments
-1. Increase system base memory to 6GB
-2. Use "Intel HD Audio" controller
-3. I installed this version: <br />
-   <http://jaws2019.vfo.digital/2019.1909.28.400/26B7F1A4-93A1-49A6-8F7D-8D030F3E3900/J2019.1909.28-any.exe>
-


### PR DESCRIPTION
Blocked by #390

Why:

- The native extension fails to compile on my local machine in the older version of html-proofer.
- We should want to update to newer versions of dependencies to take advantages of features and bug fixes.

Note that this is not the latest version of `html-proofer`. There is a 5.x version for the dependency, but it requires Ruby 3.1 or newer, which is currently incompatible with Jekyll and our Cloud.gov Pages build environment.

See upgrade guide: https://github.com/gjtorikian/html-proofer/blob/main/UPGRADING.md