### PR TITLE
Update deployment guide to adjust cadence

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -14,7 +14,7 @@ A few notes on our deploy process.
 ### Cadence
 
 **When to deploy:** ✅
-- Typically we do a full deploy twice weekly, on Mondays and Thursdays.
+- Typically we do a full deploy twice weekly, on Tuesdays and Thursdays.
 
 **When _not_ to deploy:** ❌
 - We try to avoid deploying on Fridays, to minimize the chances of introducing a


### PR DESCRIPTION
Why: As decided in Engineering Huddle 2023-03-15, we'll now be deploying on Tuesdays and Thursdays instead of Mondays and Thursdays.
