### PR TITLE
Apply design system styling to autolink links

### DIFF
--- a/_plugins/content_typography.rb
+++ b/_plugins/content_typography.rb
@@ -3,8 +3,18 @@ module Kramdown
     class Kramdown
       prepend(Module.new do
         def add_link(el, *args)
-          el.attr['class'] = [*el.attr['class'], 'usa-link'].join(' ') if el.type == :a
+          add_link_class!(el) if el.type == :a
           super(el, *args)
+        end
+
+        def parse_autolink
+          *children, el = super
+          add_link_class!(el)
+          [*children, el]
+        end
+
+        def add_link_class!(el)
+          el.attr['class'] = [*el.attr['class'], 'usa-link'].join(' ')
         end
       end)
     end


### PR DESCRIPTION
Extends existing ContentTypography plugin to apply standard design system styling to "autolinks", which are treated distinctly from Markdown-formatted links.

Copied from https://github.com/18F/identity-dev-docs/pull/319

**Screenshots:**

Example: https://handbook.login.gov/articles/platform-gitlab-env-deploy.html

Before|After
---|---
![image](https://user-images.githubusercontent.com/1779930/229189703-e9f3e72d-bf3f-48f4-906b-bb0524f4e6d3.png)|![image](https://user-images.githubusercontent.com/1779930/229189733-c1fa0919-9e6d-470a-99b9-f93e1e44e3c4.png)
