### PR TITLE
Build JavaScript files to site output directory

### DIFF
--- a/_articles/analytics-events.md
+++ b/_articles/analytics-events.md
@@ -80,7 +80,7 @@ For additional events see the [legacy Analytics Event documentation][legacy-docu
 </div>
 
 <script type="module">
-import { loadAnalyticsEvents } from '{{ "/assets/build/analytics-events.js" | prepend: site.baseurl }}';
+import { loadAnalyticsEvents } from '{{ "/assets/js/analytics-events.js" | prepend: site.baseurl }}';
 
 loadAnalyticsEvents();
 </script>

--- a/_categories/private.md
+++ b/_categories/private.md
@@ -16,7 +16,7 @@ icon: lock
 <script type="module">
   import {
     setUpPrivatePage
-  } from '{{ "/assets/build/private-articles.js" | prepend: site.baseurl }}';
+  } from '{{ "/assets/js/private-articles.js" | prepend: site.baseurl }}';
 
   setUpPrivatePage();
 </script>

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,9 @@ sass:
 copy_to_destination:
   - node_modules/identity-style-guide/dist/assets
 
+keep_files:
+  - assets/js
+
 plugins:
   - jekyll-redirect-from
   - jekyll-last-modified-at

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,7 +88,7 @@
         loadSimpleJekyllSearch,
         setUpPrivateLogin,
         installCustomTimeElements
-      } from '{{ "/assets/build/setup.js" | prepend: site.baseurl }}';
+      } from '{{ "/assets/js/setup.js" | prepend: site.baseurl }}';
 
       document.addEventListener('DOMContentLoaded', () => {
         loadAnchors();

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "typescript": "^4.6.2"
   },
   "scripts": {
-    "clean": "rm -rf assets/build",
+    "clean": "rm -rf _site/assets/js",
     "cspell": "cspell --config cspell.json --no-progress '**/*.md' --exclude 'vendor/**' --exclude 'node_modules/**'",
     "prebuild:common": "npm run clean",
-    "build:common": "esbuild `find assets/js -type f -not -name '*.min.*'` --outdir=assets/build --bundle --format=esm --splitting",
+    "build:common": "esbuild `find assets/js -type f -not -name '*.min.*'` --outdir=_site/assets/js --bundle --format=esm --splitting",
     "build:dev": "npm run build:common -- --sourcemap=inline",
     "build:prod": "npm run build:common -- --minify",
     "build": "npm run build:prod",


### PR DESCRIPTION
This is essentially the same as what had been implemented in the brochure site in https://github.com/18F/identity-site/pull/1011, and all of the same benefits described there apply here. This should also fix an error which sometimes occurs due to Jekyll watching JavaScript assets which are deleted as part of the JavaScript build ("No such file or directory @ rb_file_s_stat").

Testing instructions:

- Ensure preview JavaScript behaviors work as expected (no 404s in network tab, search and anchor links initialize as expected)
- Ensure that local Jekyll build does not clobber JavaScript assets:

```
rm -rf _site
npm run build
bundle exec jekyll build
ls _site/assets/js
```