### PR TITLE
Note new idv_unavailable flag in vendor outage response process

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -25,3 +25,16 @@ To do the configuration change, edit the configuration (per the [guidance here](
 Once the restart completes, users in affected flows will be presented with an error message explaining the outage, or redirected to an error page if they are unable to continue.
 
 Once we have received word that the vendor is back up and running, simply re-edit the configuration to delete the vendor status, or explicitly set it to `operational`.
+
+### Disabling identity verification (IdV)
+
+Remote unsupervised identity verification depends on certain vendors being available to process requests. If one of the required vendors marked as `full_outage`, IdV will be unavailable and users will be shown an error message.
+
+Alternately, operators can explicitly disable IdV using the `idv_available` configuration key:
+
+```yaml
+# Setting idv_available to false will disable
+# remove unsupervised identity verification. 
+# Users will be shown an error message instead.
+idv_available: false
+```

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -16,7 +16,6 @@ Currently, this is available for the following vendors:
 
 The possible values are:
 - `operational`
-- `partial_outage` (not yet implemented)
 - `full_outage`
 
 The default value is `operational`, set in `config/application.yml.default`


### PR DESCRIPTION
Issue: [LG-8710](https://cm-jira.usa.gov/browse/LG-8710)

We've added a new config flag, `idv_available`, that can be used to disable remote unsupervised identity verification (this augments the existing `vendor_status_*` flags).

This PR updates the vendor outage response process documentation to include a note about this flag. 

(I since I was in there, I also removed references to `partial_outage`--support for this was not implemented.)