### PR TITLE
Update appdev-deploy.html

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -77,13 +77,22 @@ Once you've run through proofing in staging, the next step is to cut a release f
 
 #### Cut a release branch
 
-The release branch should be cut from code tested in staging and it should be the date of the production release (ex `stages/rc-2020-06-17`):
+The release branch should be cut from code tested in staging and it should be the date of the production release (ex `stages/rc-2023-06-17`):
 
+For IdP:
 ```bash
-cd identity-$REPO
+cd identity-idp
 git fetch
 git checkout $(curl --silent https://idp.staging.login.gov/api/deploy.json | jq -r .git_sha)
-git checkout -b stages/rc-2020-06-17 # CHANGE THIS DATE
+git checkout -b stages/rc-2023-06-17 # CHANGE THIS DATE
+git push -u origin HEAD
+```
+For pki:
+```bash
+cd identity-pki
+git fetch
+git checkout $(curl --silent https://checking-deploy.pivcac.staging.login.gov/api/deploy.json | jq -r .git_sha)
+git checkout -b stages/rc-2023-06-17 # CHANGE THIS DATE
 git push -u origin HEAD
 ```
 


### PR DESCRIPTION
Split out idp vs pki release branch creation to provide easily copy/pasteable commands for pki sha capture