### PR TITLE
Add "ATO" to glossary

### DIFF
--- a/_articles/glossary.md
+++ b/_articles/glossary.md
@@ -43,6 +43,15 @@ Login.gov supports
 
 An association of DMVs from many states, AAMVA provides an API we use to validate driver's license data.
 
+### ATO
+**Authority to Operate**
+
+The approval for a government system to be run in production, and the compliance process for getting there.
+
+At Login.gov, only our production and staging environments have an authority to operate permitting them to accept [personally-identifiable information (PII)](#pii).
+
+Source: [TTS Handbook _Lifecycle of a Launch_](https://handbook.tts.gsa.gov/launching-software/lifecycle/#atos), [OpenControl's Introduction to ATOs](https://atos.open-control.org/)
+
 ### Authentication
 **AuthN**
 


### PR DESCRIPTION
Why? It had come up in conversation in discussing our deployed environments, since "ATO" is often a distinguishing factor between them.