### PR TITLE
Add "Back to top" link with every analytic listing

### DIFF
--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -198,6 +198,7 @@ function Event({ event }: { event: AnalyticsEvent }) {
         previous_event_names={previousEventNames}
         attributes={attributes}
       />
+      <a href="#main-content">Back to top</a>
     </div>
   );
 }

--- a/assets/js/analytics-events.tsx
+++ b/assets/js/analytics-events.tsx
@@ -198,7 +198,11 @@ function Event({ event }: { event: AnalyticsEvent }) {
         previous_event_names={previousEventNames}
         attributes={attributes}
       />
-      <a href="#main-content">Back to top</a>
+      <small>
+        <a href="#main-content" className="usa-link">
+          Back to top
+        </a>
+      </small>
     </div>
   );
 }


### PR DESCRIPTION
Scrolling back to the top got annoying and it is not a very good user experience, so I added a "Back to top" link