### PR TITLE
Upgrade Login.gov Design System to v7.0.1

### DIFF
--- a/_articles/github.md
+++ b/_articles/github.md
@@ -102,10 +102,8 @@ View a [list of all repositories](https://github.com/topics/login-gov) tagged fo
   Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
   Public marketing page.
 
-- [**`18f/identity-style-guide`**](https://github.com/18f/identity-style-guide)<br />
-  [design.login.gov](https://design.login.gov)<br />
-  Hosted on: [Cloud.gov Pages](https://pages.cloud.gov/)<br />
-  Walkthrough of Login.gov common styles. The repository also hosts the `identity-style-guide` npm package that contains the actual styles.
+- [**`18f/identity-design-system`**](https://github.com/18f/identity-design-system)<br />
+  The Login.gov Design System, an extension of the U.S. Web Design System used on Login.gov sites to consistently identify the Login.gov brand.
 
 - [**`18f/identity-dev-docs`**](https://github.com/18f/identity-dev-docs)<br />
   [developers.login.gov](https://developers.login.gov)<br />

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ sass:
     - node_modules
 
 copy_to_destination:
-  - node_modules/identity-style-guide/dist/assets
+  - node_modules/@18f/identity-design-system/dist/assets
 
 keep_files:
   - assets/js

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,39 +15,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body data-base-url="{{site.baseurl}}">
-    <header class="usa-header usa-header--basic" role="banner">
-      <div class="usa-nav-container">
-        <div class="usa-navbar">
-          <div class="usa-logo" id="basic-logo">
-            <a href="/" title="Home" aria-label="Home">
-              <img src="{{site.baseurl}}/assets/img/login-gov-logo.svg" class="usa-logo__img" alt="Login.gov" />
-              <em class="usa-logo__text">Handbook</em>
-            </a>
-          </div>
-          <!--
-            <button class="usa-menu-btn">Menu</button>
-          -->
+    <header class="usa-header usa-header--extended">
+      <div class="usa-navbar">
+        <div class="usa-logo">
+          <a href="/" title="Home" aria-label="Home">
+            <img src="{{ site.baseurl }}/assets/img/login-gov-logo.svg" class="usa-logo__img" alt="Login.gov" />
+            <em class="usa-logo__text">Handbook</em>
+          </a>
         </div>
-        <nav role="navigation" class="usa-nav">
-          <button class="usa-nav__close"><img src="/assets/img/close.svg" alt="Close"></button>
-          <ul class="usa-nav__primary usa-accordion">
-            <!-- TODO: nav elements -->
-          </ul>
-
-          <ul class="usa-nav__secondary-links">
-            <li class="usa-nav__secondary-item">
-              <span id="private-login-button-container" class="margin-right-1"></span>
-            </li>
-          </ul>
-
-          <div class="usa-nav__secondary-container">
-            <div class="usa-search usa-search--small" role="search">
-              <label class="usa-sr-only" for="basic-search-field-small">Search small</label>
-              <input type="text" id="search-input" name="search" placeholder="Search articles...">
-              <ul id="search-results"></ul>
-            </div>
+        <div class="grid-container tablet:margin-0 tablet:padding-0">
+          <div class="flex-row flex-align-center grid-row grid-gap-1">
+            <ul class="usa-nav__secondary-links grid-col grid-col-auto margin-0">
+              <li class="usa-nav__secondary-item" id="private-login-button-container"></li>
+            </ul>
+            <form class="usa-search usa-search--small grid-col grid-col-fill" role="search">
+              <label class="usa-sr-only" for="search-input">Search articles</label>
+              <input class="usa-input width-auto" type="search" id="search-input" placeholder="Search articles...">
+              <button class="usa-button" type="submit">
+                <span class="usa-search__submit-text">Search</span>
+              </button>
+              <ul id="search-results" tabindex="-1"></ul>
+            </form>
           </div>
-        </nav>
+        </div>
       </div>
     </header>
     <main class="usa-layout-docs usa-section" id="main-content">

--- a/assets/js/setup.ts
+++ b/assets/js/setup.ts
@@ -53,11 +53,20 @@ export const loadPrivateEye = () => {
 };
 
 export const loadSimpleJekyllSearch = () => {
+  const searchResults = document.getElementById("search-results")!;
   (window as SimpleJekyllSearchGlobals).SimpleJekyllSearch({
     searchInput: document.getElementById("search-input") as HTMLElement,
-    resultsContainer: document.getElementById("search-results") as HTMLElement,
+    resultsContainer: searchResults,
     json: `${document.body.dataset.baseUrl}/search.json`,
     noResultsText: '<li class="no-results">No results were found.</li>',
+  });
+
+  const searchForm = document.querySelector<HTMLFormElement>(
+    '.usa-header [role="search"]'
+  )!;
+  searchForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    searchResults.focus();
   });
 };
 

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,5 +1,5 @@
 // Imports
-@import "identity-style-guide/dist/assets/scss/packages/required";
+@use "uswds-core" as *;
 
 // Hello! These styles are specific styles for
 // the Login.gov Handbook. Please refer to design.login.login-gov

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,11 +1,17 @@
 // Imports
 @use "uswds-core" as *;
 
-// Hello! These styles are specific styles for
-// the Login.gov Handbook. Please refer to design.login.login-gov
-// for the broader design system to follow. kthxbai.
+.usa-search [type="submit"] {
+  // Temporary: To be incorporated in LGDS 7.0.1
+  // See: https://github.com/18F/identity-design-system/pull/354
+  flex-shrink: 0;
+}
 
-// Search
+.usa-header--extended .usa-navbar {
+  // The header has a default overflow which prevents search results from showing outside.
+  overflow: visible;
+}
+
 #search-results {
   background-color: #ebf3fa;
   position: absolute;

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -1,12 +1,6 @@
 // Imports
 @use "uswds-core" as *;
 
-.usa-search [type="submit"] {
-  // Temporary: To be incorporated in LGDS 7.0.1
-  // See: https://github.com/18F/identity-design-system/pull/354
-  flex-shrink: 0;
-}
-
 .usa-header--extended .usa-navbar {
   // The header has a default overflow which prevents search results from showing outside.
   overflow: visible;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "identity-handbook",
       "dependencies": {
         "@18f/identity-build-sass": "^1.1.0",
+        "@18f/identity-design-system": "^7.0.1-beta.1",
         "@18f/private-eye": "^2.1.0",
         "anchor-js": "^4.2.2",
         "concurrently": "^8.0.1",
         "esbuild": "^0.17.15",
         "htm": "^3.1.0",
-        "identity-style-guide": "^6.5.0",
         "js-yaml": "^4.1.0",
         "marked": "^4.0.12",
         "preact": "^10.6.6",
@@ -93,6 +92,18 @@
       },
       "bin": {
         "build-sass": "cli.js"
+      }
+    },
+    "node_modules/@18f/identity-design-system": {
+      "version": "7.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
+      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "dependencies": {
+        "@uswds/uswds": "^3.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">6"
       }
     },
     "node_modules/@18f/private-eye": {
@@ -1282,6 +1293,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "dependencies": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -2252,11 +2277,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -3198,19 +3218,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.0.tgz",
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
-    },
-    "node_modules/identity-style-guide": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
-      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
-      "dependencies": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">6"
-      }
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -5032,21 +5039,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "dependencies": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -5236,6 +5228,14 @@
         "chokidar": "^3.5.3",
         "lightningcss": "^1.16.1",
         "sass-embedded": "^1.56.1"
+      }
+    },
+    "@18f/identity-design-system": {
+      "version": "7.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
+      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "requires": {
+        "@uswds/uswds": "^3.4.1"
       }
     },
     "@18f/private-eye": {
@@ -6065,6 +6065,17 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
+    "@uswds/uswds": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.4.1.tgz",
+      "integrity": "sha512-eLYbWUqf9eWUa2P6CO3ckIjtQyM3AylrIOHxN5gYG3P62TDd3FzRDyoACfvOe6CNk0w0PqXWJnuPzxpNoOgWNA==",
+      "requires": {
+        "classlist-polyfill": "1.0.3",
+        "object-assign": "4.1.1",
+        "receptor": "1.0.0",
+        "resolve-id-refs": "0.1.0"
+      }
+    },
     "acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -6744,11 +6755,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
     },
     "dot-prop": {
       "version": "5.3.0",
@@ -7456,15 +7462,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.0.tgz",
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
-    },
-    "identity-style-guide": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/identity-style-guide/-/identity-style-guide-6.5.0.tgz",
-      "integrity": "sha512-P/ZsOodZn3XyX6LYgrtDKzWe447rPkTUxAYADIGAcl13wv7ghQZJjaL1g1PySzG5PAvxeeoyOJYfRW58NRMUCw==",
-      "requires": {
-        "domready": "1.0.8",
-        "uswds": "^2.13.3"
-      }
     },
     "ignore": {
       "version": "5.2.0",
@@ -8674,18 +8671,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "uswds": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.13.3.tgz",
-      "integrity": "sha512-qCblljeaRvS3+PrSxoHqQwmMnp746+Y1YZA34BkTzJknvo2bhhdzGE21yJaInumzIqV3glLD13TFdRwrwikMMQ==",
-      "requires": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
-        "object-assign": "4.1.1",
-        "receptor": "1.0.0",
-        "resolve-id-refs": "0.1.0"
       }
     },
     "v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@18f/identity-build-sass": "^1.1.0",
-        "@18f/identity-design-system": "^7.0.1-beta.1",
+        "@18f/identity-design-system": "^7.0.1",
         "@18f/private-eye": "^2.1.0",
         "anchor-js": "^4.2.2",
         "concurrently": "^8.0.1",
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@18f/identity-design-system": {
-      "version": "7.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
-      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
+      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
       "dependencies": {
         "@uswds/uswds": "^3.4.1"
       },
@@ -5231,9 +5231,9 @@
       }
     },
     "@18f/identity-design-system": {
-      "version": "7.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1-beta.1.tgz",
-      "integrity": "sha512-blJhBPG7QXZH3B8CaMR95DWDfRDy9KLYKUkJzgzUkN+w5NVUovJmdv1B/SaEw6Vvr8cBV1/Ovo1h/jLq50+mPA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-7.0.1.tgz",
+      "integrity": "sha512-5KblBGmHLrsLGsF0cCThnkBWG0ZK+sP9NQln4FyEYXs0dzzGr0duhtqnMfGUZr6dj6ziZZjFCTmP8WNlkkpclA==",
       "requires": {
         "@uswds/uswds": "^3.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
     "@18f/identity-build-sass": "^1.1.0",
+    "@18f/identity-design-system": "^7.0.1-beta.1",
     "@18f/private-eye": "^2.1.0",
     "anchor-js": "^4.2.2",
     "concurrently": "^8.0.1",
     "esbuild": "^0.17.15",
     "htm": "^3.1.0",
-    "identity-style-guide": "^6.5.0",
     "js-yaml": "^4.1.0",
     "marked": "^4.0.12",
     "preact": "^10.6.6",
@@ -38,7 +38,7 @@
     "build:js:dev": "npm run build:js:common -- --sourcemap=inline",
     "build:js:prod": "npm run build:js:common -- --minify",
     "prebuild:css": "mkdir -p _site/assets/css",
-    "build:css": "build-sass assets/scss/*.scss --out-dir=_site/assets/css",
+    "build:css": "build-sass assets/scss/*.scss --out-dir=_site/assets/css --load-path=node_modules/@18f/identity-design-system/packages",
     "build": "concurrently npm:build:js:prod npm:build:css",
     "watch:js:dev": "npm run build:js:dev -- --watch",
     "watch:css": "npm run build:css -- --watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@18f/identity-build-sass": "^1.1.0",
-    "@18f/identity-design-system": "^7.0.1-beta.1",
+    "@18f/identity-design-system": "^7.0.1",
     "@18f/private-eye": "^2.1.0",
     "anchor-js": "^4.2.2",
     "concurrently": "^8.0.1",


### PR DESCRIPTION
Upgrades the Login.gov Design System from v6.5.0 to v7.0.1 (currently beta, but will target stable release prior to merge).

Preview link: https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/aduth-lgds-7/
Compare to live: https://handbook.login.gov/

One difference/regression I notice here that might be worth resolving before the stable release of 7.0.1 is that the handbook's use of the "basic" header lost the vertical centering of the right-hand content in the refactoring of https://github.com/18F/identity-design-system/pull/352 .