### PR TITLE
Update offboarding.md

### DIFF
--- a/_articles/offboarding.md
+++ b/_articles/offboarding.md
@@ -15,25 +15,12 @@ Review the [Leaving TTS page in the TTS Handbook](https://handbook.tts.gsa.gov/l
 
 ### For offboarding assistant to complete
 
-- - Add a new JIRA Issue to the [People-Ops board](https://cm-jira.usa.gov/secure/RapidBoard.jspa?projectKey=LPO&rapidView=2861) to track completion of offboarding tasks.
-  - `Create Bulk Sub Tasks` on the new issue and use the `Login.gov Offboarding Assistant Tasks` template.
-- If this person is leaving GSA/TTS, review and share [leaving GSA/TTS guidance](https://handbook.tts.gsa.gov/leaving-tts/).
-  - If this person is unable to [email their resignation letter](https://handbook.tts.gsa.gov/leaving-tts/#1-email-your-resignation-letter) for any reason you must do it on their behalf. **This also applies to contractors**.
-- If applicable, send an email to the Login.gov team announcing that this employee is leaving Login.gov
 - [Create a new issue in the `identity-devops` GitHub repository using the off-boarding template](https://github.com/18F/identity-devops/issues/new?template=offboard-devops.md) and ping `@login-devops-oncall` in Slack to alert them to the new offboarding issue.  Tip: [view current AWS users](https://github.com/18F/identity-devops/blob/main/terraform/master/global/main.tf#L93)
 - Check in `#admins-github` to ensure that GitHub access for this person has been removed (TTS `#people-ops` is usually on top of this). If this person is moving elsewhere in TTS ensure they have been removed from `identity-*` [GitHub teams](https://github.com/orgs/18F/teams/). Cc `@github-admins-slack` on your request.
   - Note that CircleCI, CodeClimate, and Snyk rights are removed via GitHub integration
 - [Using the JIRA Portal](https://cm-jira.usa.gov/servicedesk/customer/portal/11), choose `Application Access` and request that the user be removed from the Login.gov project (and deactivated if they are no longer working for GSA).
-- Use the [TTS Slack Form](https://goo.gl/forms/mKATdB9QuNo7AXVY2) to submit user modification
 - Remove from [Login.gov Slack groups]({% link _articles/slack.md %}).
 - Remove from [all accounts]({% link _articles/accounts.md %})
-  - [Remove user from Login.gov Google Groups](https://groups.google.com/a/gsa.gov/forum/#!myforums)
-  - [Remove the user from Hubspot](https://app.hubspot.com/settings/5531666/users)
-  - [Remove user from Figma](https://www.figma.com/files/team/893580939040886405/Login.gov/members)
-  - Remove the user from the [`gsa-login-prototyping` cloud.gov org](https://dashboard.fr.cloud.gov/cloud-foundry/2oBn9LBurIXUNpfmtZCQTCHnxUM/organizations/fc240d49-f678-4325-8384-c88d92d60982/users)
-  - Remove the user as admins from any dashboards
-    - [Login.gov dashboard](https://dashboard.int.identitysandbox.gov)
-    - [search.gov dashboard](https://search.gov)
 - Update the [Login.gov org chart](https://docs.google.com/spreadsheets/d/1tiTR2ohdl0NIsrF4gJjNipEZ0z0oq1pOFWYjHg8Tbi0/edit#gid=0)
 
 ## Partial Offboarding


### PR DESCRIPTION
We have a team member who is rolling-off Team Ada later this month, and I was asked to ensure this [offboarding](https://handbook.login.gov/articles/offboarding.html) was completed. While reviewing that checklist, I noticed a few things were out-of-date, so this is a Pull Request to suggest edits. (I am open to us choosing to do less - or more! - with this change.)

In no particular order...
1. I don't think the referenced People-Ops JIRA board is still used (it shows either as hidden or deleted)
2. The TTS Slack Form is now in ServiceNow; but it's unclear if we need that form, or if it should be under "Services"
3. The "all accounts" section links to [Services and Accounts](https://handbook.login.gov/articles/accounts.html) which seems better than duplicating content here