### PR TITLE
Add article for AppDev team daytime oncall

### DIFF
--- a/_articles/appdev-team-daytime-oncall.md
+++ b/_articles/appdev-team-daytime-oncall.md
@@ -19,7 +19,7 @@ subcategory: Oncall
 * The oncall should fix the issue immediately if it is urgent, or otherwise create a ticket if there is a non-urgent bug to be fixed.
 * "Daytime" is defined as the working hours for the person(s) on the daytime oncall rotation, typically 9am to 5pm in the local time. If an issue is escalated outside working hours, it's expected and understood that the task will be handled the next business day during business hours.
 
-## Managing On-Call
+## Managing Oncall
 
 * It is up to the individual teams to decide how they want to manage their team's oncall. The only requirement is that someone is always reachable by the team oncall Slack handle.
   * Some example variations include:

--- a/_articles/appdev-team-daytime-oncall.md
+++ b/_articles/appdev-team-daytime-oncall.md
@@ -1,0 +1,28 @@
+---
+title: "Team Daytime Oncall"
+description: "Responsibilities for individual team daytime oncall"
+layout: article
+category: AppDev
+subcategory: Oncall
+---
+
+## Overview
+
+* Each AppDev sprint team has its own daytime team-specific oncall rotation, to resolve issues related to that team.
+* This role complements the [overnight oncall rotation]({% link _articles/appdev-oncall-guide.md %}), distributing the burden of work, moving ownership of issues closer to the responsible teams, and preparing individuals to become familiar with oncall procedures.
+* The overnight oncall rotation is a first responder; they will triage incoming issues reported during daytime hours, delegating responsibility to team oncall to investigate, fix, or create relevant tickets.
+
+## Expectations
+
+* Each team's oncall should be reachable by a Slack group handle `@login-TEAM-oncall`.
+* When issues are escalated to team oncall, the oncall should respond within 15 business minutes.
+* The oncall should fix the issue immediately if it is urgent, or otherwise create a ticket if there is a non-urgent bug to be fixed.
+* "Daytime" is defined as the working hours for the person(s) on the daytime oncall rotation, typically 9am to 5pm in the local time. If an issue is escalated outside working hours, it's expected and understood that the task will be handled the next business day during business hours.
+
+## Managing On-Call
+
+* It is up to the individual teams to decide how they want to manage their team's oncall. The only requirement is that someone is always reachable by the team oncall Slack handle.
+  * Some example variations include:
+    * Rotations every week, or every sprint
+    * Single oncall, or primary and back-up oncall
+* Consider using a spreadsheet to manage the list of engineers in the rotation and the timeline of the rotation ([example spreadsheet](https://docs.google.com/spreadsheets/d/1tAEScH-1A1708a5elOuLDEHj7p_JzFdkpbNGB33gDJU/edit#gid=0))


### PR DESCRIPTION
**Why?**

* So that individuals and teams can understand the expectations around the role

**Live preview:** https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/aduth-team-oncall/articles/appdev-team-daytime-oncall.html

**Reference document:** https://docs.google.com/document/d/1UEwJRhjy4FciHu7XGZi5_y17K5kG1AO3iS9U5qCWo5I/edit