### PR TITLE
Update deploy timing documentation

### DIFF
--- a/_articles/daily-deploy-schedule.md
+++ b/_articles/daily-deploy-schedule.md
@@ -6,7 +6,7 @@ category: "AppDev"
 subcategory: "Deploying"
 ---
 
-### Apps
+## Apps
 
 These apps are deployed on weekdays:
 
@@ -14,9 +14,9 @@ These apps are deployed on weekdays:
 - PKI
 - Dashboard
 
-### Daily Business Schedule Deploys
+## Daily Business Schedule Deploys
 
-#### Staging and INT
+### Staging and INT
 
 In staging, daily deploys are scheduled for **weekdays at 5pm UTC**.
 
@@ -34,7 +34,7 @@ See the [int schedule][int-specific-timing] for the time it's set to deploy. Def
 [int-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
 [int-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/int.tfvars#L4-L5
 
-### Every 6 Hours Deploy Schedule
+## Every 6 Hours Deploy Schedule
 
 In these environments
 
@@ -50,16 +50,16 @@ Deploys are scheduled every 6 hours at **5am, 11am, 5pm, 11pm UTC**.
 | 5pm  | <lg-local-time utc="5pm" />    |
 | 11pm | <lg-local-time utc="11pm" />   |
 
-### Not being deployed automatically
+## Not being deployed automatically
 
-#### DM
+### DM
 
 See the [dm schedule][dm-specific-timing] for the time it's set to deploy (currently, `nozero_norecycle`), and [the dm variables][dm-specific-time-zone] for the time zone.
 
 [dm-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L3-L7
 [dm-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/dm.tfvars#L4-L5
 
-#### PT
+### PT
 
 See the [pt settings][pt-settings] for further info.
 

--- a/_articles/daily-deploy-schedule.md
+++ b/_articles/daily-deploy-schedule.md
@@ -16,24 +16,20 @@ These apps are deployed on weekdays:
 
 ### Daily Business Schedule Deploys
 
-#### Staging
+#### Staging and INT
 
-| Eastern  |
-|----------|
-| 5pm      |
-
-In staging, daily deploys are scheduled for **weekdays at 5pm Eastern**. See the [staging schedule][staging-specific-timing] for the time it's set to deploy, and [the staging variables][staging-specific-time-zone] for the time zone.
-
-[staging-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
-[staging-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/staging.tfvars#L4-L5
-
-#### INT
+In staging, daily deploys are scheduled for **weekdays at 5pm UTC**.
 
 | UTC  | Local (<lg-local-zone-name />) |
 |------|--------------------------------|
 | 5pm  | <lg-local-time utc="5pm" />    |
 
+See the [staging schedule][staging-specific-timing] for the time it's set to deploy. Default is UTC, and staging has the [overwrite timezone setting][staging-specific-time-zone] commented out.
+
 See the [int schedule][int-specific-timing] for the time it's set to deploy. Default is UTC, and int has the [overwrite timezone setting][int-specific-time-zone] commented out.
+
+[staging-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
+[staging-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/staging.tfvars#L4-L5
 
 [int-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
 [int-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/int.tfvars#L4-L5

--- a/_articles/daily-deploy-schedule.md
+++ b/_articles/daily-deploy-schedule.md
@@ -16,21 +16,27 @@ These apps are deployed on weekdays:
 
 ### Daily Business Schedule Deploys
 
-In these environments
+#### Staging
 
-- int
-- pt
-- staging
-- dm
+| Eastern  |
+|----------|
+| 5pm      |
 
-The daily deploys are scheduled for **weekdays at 5pm UTC**. See
-the [daily business schedule in identity-devops][identity-devops-schedule].
+In staging, daily deploys are scheduled for **weekdays at 5pm Eastern**. See the [staging schedule][staging-specific-timing] for the time it's set to deploy, and [the staging variables][staging-specific-time-zone] for the time zone.
+
+[staging-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
+[staging-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/staging.tfvars#L4-L5
+
+#### INT
 
 | UTC  | Local (<lg-local-zone-name />) |
 |------|--------------------------------|
 | 5pm  | <lg-local-time utc="5pm" />    |
 
-[identity-devops-schedule]: https://github.com/18F/identity-terraform/blob/3a37047cfae6949dab1150025c528ccc5332f837/asg_recycle/main.tf#L44-L78
+See the [int schedule][int-specific-timing] for the time it's set to deploy. Default is UTC, and int has the [overwrite timezone setting][int-specific-time-zone] commented out.
+
+[int-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L15-L20
+[int-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/int.tfvars#L4-L5
 
 ### Every 6 Hours Deploy Schedule
 
@@ -47,6 +53,21 @@ Deploys are scheduled every 6 hours at **5am, 11am, 5pm, 11pm UTC**.
 | 11am | <lg-local-time utc="11am" />   |
 | 5pm  | <lg-local-time utc="5pm" />    |
 | 11pm | <lg-local-time utc="11pm" />   |
+
+### Not being deployed automatically
+
+#### DM
+
+See the [dm schedule][dm-specific-timing] for the time it's set to deploy (currently, `nozero_norecycle`), and [the dm variables][dm-specific-time-zone] for the time zone.
+
+[dm-specific-timing]: https://github.com/18F/identity-terraform/blob/main/asg_recycle/schedule.tf#L3-L7
+[dm-specific-time-zone]: https://github.com/18F/identity-devops-private/blob/main/vars/dm.tfvars#L4-L5
+
+#### PT
+
+See the [pt settings][pt-settings] for further info.
+
+[pt-settings]: https://github.com/18F/identity-devops-private/blob/main/vars/pt.tfvars#L6
 
 ### Environment status
 


### PR DESCRIPTION
While watching staging to see a recent feature deploy, I found that the deploy timing didn't match the documentation. In this [conversation in Slack](https://gsa-tts.slack.com/archives/C16RSBG49/p1686596434193659), @mitchellhenke helped me find the current times staging is deployed.

The deeper I dug into it, the more I found a lot of the deploy times were out of date, as were a few links. Not many of them have the same schedule anymore, and the location notating the timing is in a new file now. [The original identity-devops-schedule](https://github.com/18F/identity-terraform/blob/3a37047cfae6949dab1150025c528ccc5332f837/asg_recycle/main.tf#L44-L78) is no longer a valid link and is not where the schedules are kept.

Because of these reasons, I gave the envs their own subheadings.

Other notes:

- Chose "Eastern" as the label for staging
    - I didn't see an easy way to transform the times to UTC from Eastern without writing some custom JS as we did to transform _from_ UTC.
    - I also didn't want to have to worry about updating EDT vs EST every 6 months for daylight savings time.
- PT doesn't have any of the `autoscaling_time` vars set, but does have `idp_cpu_autoscaling_enabled = 0` so I think that means it isn't refreshing automatically