### PR TITLE
Add note on using sms-me

### DIFF
--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -320,6 +320,23 @@ aws-vault exec sandbox-power --
     ./bin/scp-s3 i-abcdef1234:/tmp/file.txt ./file.txt
 ```
 
+## `sms-me`
+
+`sms-me` sends a test SMS message from each production region to a test phone
+number. It allows for quick testing in case of a full or partial SMS outage.
+(Production access is required to use this tool.)
+
+Replace `YOUR_PHONE_NUMBER` with the number you would like to send to.
+Enter a 10 digit phone number. The script automatically adds the `+1` country
+code.
+
+```bash
+aws-vault exec sms-prod-power -- ./bin/sms-me YOUR_PHONE_NUMBER
+```
+
+The script returns message IDs that can be checked against the SMS
+delivery logs.
+
 ## `ssm-instance`
 
 `ssm-instance` opens an interactive session with a server (EC2 instance)

--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -326,10 +326,11 @@ aws-vault exec sandbox-power --
 number. It allows for quick testing in case of a full or partial SMS outage.
 (Production access is required to use this tool.)
 
-Replace `YOUR_PHONE_NUMBER` with the number you would like to send to.
+Replace `PHONE_NUMBER` with the number you would like to send to.
+(Make sure this number is your own or somebody's that you have permission to use.)
 
 ```bash
-aws-vault exec sms-prod-power -- ./bin/sms-me YOUR_PHONE_NUMBER
+aws-vault exec sms-prod-power -- ./bin/sms-me PHONE_NUMBER
 ```
 
 The script returns message IDs that can be checked against the SMS

--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -327,8 +327,6 @@ number. It allows for quick testing in case of a full or partial SMS outage.
 (Production access is required to use this tool.)
 
 Replace `YOUR_PHONE_NUMBER` with the number you would like to send to.
-Enter a 10 digit phone number. The script automatically adds the `+1` country
-code.
 
 ```bash
 aws-vault exec sms-prod-power -- ./bin/sms-me YOUR_PHONE_NUMBER


### PR DESCRIPTION
Adds usage of the `sms-me` command for quickly testing SMS from all US production numbers.

Related PR: https://github.com/18F/identity-devops/pull/6358