### PR TITLE
Update the deploy guide to include a note about the new slack workflow

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -144,8 +144,7 @@ Staging used to be deployed by this process, but this was changed to deploy the 
 ### Production
 
 1. Merge the production promotion pull request (**NOT** a squashed merge, just a normal merge)
-1. Notify in Slack (`#login-appdev` and `#login-devops` channels)
-    - e.g. `:recycle:  Starting idp RC <RELEASE_NUMBER> deploy to Production`
+1. Notify in Slack using the IDP recycle workflow in the `login-appdev` channel.
 1. In the `identity-devops` repo:
    ```bash
    cd identity-devops


### PR DESCRIPTION
I just added a slack workflow for announcing deploys. This commit updates the docs to tell peeople to use it to announce deploys.