### PR TITLE
Clarify patch deploy ownership and deployer responsibilities

### DIFF
--- a/_articles/appdev-deploy-rotation.md
+++ b/_articles/appdev-deploy-rotation.md
@@ -11,6 +11,19 @@ Each week a new engineer is assigned from the rotation.
 
 See the [rotation spreadsheet](https://docs.google.com/spreadsheets/d/1nLxhwVh4EfxdmqsvdFByxTk0bNSTyWGGBEXLODjlk6U/edit#gid=0).
 
+## Responsibilities of the deployer
+
+The deployer is responsible for the [twice-weekly deployments](deploy-guide) for IdP and PKI application revisions.
+
+A deployer should coordinate with the rest of the AppDev team as part of the release cycle:
+
+- Compiling and sharing release notes, as outlined in the [deploy guide](deploy-guide)
+- Making requested revisions to release notes
+- Accommodating reasonable requests for late or patch revisions to a release candidate branch
+- Sharing progress updates during the deploy itself
+
+[deploy-guide]: {% link _articles/appdev-deploy.md %}
+
 ## Overriding the deployer for a given week
 
 Occasionally a deployer will need to trade weeks with another deployer to provide coverage.

--- a/_articles/appdev-deploy-rotation.md
+++ b/_articles/appdev-deploy-rotation.md
@@ -13,11 +13,11 @@ See the [rotation spreadsheet](https://docs.google.com/spreadsheets/d/1nLxhwVh4E
 
 ## Responsibilities of the deployer
 
-The deployer is responsible for the [twice-weekly deployments](deploy-guide) for IdP and PKI application revisions.
+The deployer is responsible for the [twice-weekly deployments][deploy-guide] for IdP and PKI application revisions.
 
 A deployer should coordinate with the rest of the AppDev team as part of the release cycle:
 
-- Compiling and sharing release notes, as outlined in the [deploy guide](deploy-guide)
+- Compiling and sharing release notes, as outlined in the [deploy guide][deploy-guide]
 - Making requested revisions to release notes
 - Accommodating reasonable requests for late or patch revisions to a release candidate branch
 - Sharing progress updates during the deploy itself

--- a/_articles/appdev-deploy-rotation.md
+++ b/_articles/appdev-deploy-rotation.md
@@ -15,7 +15,7 @@ See the [rotation spreadsheet](https://docs.google.com/spreadsheets/d/1nLxhwVh4E
 
 The deployer is responsible for the [twice-weekly deployments][deploy-guide] for IdP and PKI application revisions.
 
-A deployer should coordinate with the rest of the AppDev team as part of the release cycle:
+A deployer should coordinate with the rest of the AppDev team and the [AppDev oncall]({% link _articles/appdev-oncall-guide.md %}) as part of the release cycle:
 
 - Compiling and sharing release notes, as outlined in the [deploy guide][deploy-guide]
 - Making requested revisions to release notes

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -30,7 +30,7 @@ the `stages/prod` branch.
 | Type | What | When | Who |
 | ---- | ---- | ---- | --- |
 | **Full Deploy** |  The normal deploy, releases all changes on the `main`  branch to production. | Twice a week | [@login-deployer][deployer-rotation] |
-| **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | [@login-deployer][deployer-rotation], or engineer handling the urgent issue |
+| **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | The engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
 | **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
 | **Config Recycle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |


### PR DESCRIPTION
Updates language to clarify expectations of the deployer, and specifically that the deployer is not directly responsible for any ad hoc patch releases that need to be deployed, but that they should make reasonable accommodations for patch revisions to the routine RC deploy branches.