### PR TITLE
LG-10639 Mention AAMVA in vendor outage page

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -308,7 +308,7 @@ new configurations (config from S3).
     ```
 
 ### No-Migration Recycle
-When responding to a production incident with a config change, or otherwise in a hurry, you might want to recycle without waiting for a migration instance. Note that if a migration has been introduced on main (for environments other than prod), new instances will fail to start until migrations are run.
+When responding to a production incident with a config change, or otherwise in a hurry, you might want to recycle without waiting for a migration instance. For environments other than prod, note that if a migration has been introduced on `main`, new instances will fail to start until migrations are run.
 1. Recycle the boxes without a migration instance
 ```bash
 aws-vault exec prod-power -- ./bin/asg-recycle prod idp --skip-migration

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -33,7 +33,8 @@ the `stages/prod` branch.
 | **Patch Deploy** | A deploy that cherry-picks particular changes to be deployed | For urgent bug fixes | The engineer handling the urgent issue |
 | **Off-Cycle/Mid-Cycle Deploy** | Releases all changes on the `main` branch, sometime during the middle of a sprint | As needed, or if there are too many changes needed to cleanly cherry-pick as a patch | The engineer that needs the changes deployed |
 | **Passenger Restart** | A "deploy" that just updates configurations without the need to scale up/down instances like the config recycle below, does not deploy any new code, see [passenger restart](#passenger-restart) | As needed | The engineer that needs the changes deployed |
-| **Config Recycle** | A "deploy" that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
+| **Config Recycle** | A deploy that just updates configurations, and does not deploy any new code, see [config recycle](#config-recycle) | As needed | The engineer that needs the changes deployed |
+| **No-Migration Recycle** | A deploy that skips migrations, see [no-migration recycle](#no-migration-recycle) | As needed | The engineer that needs the changes deployed |
 
 [deployer-rotation]: {% link _articles/appdev-deploy-rotation.md %}
 
@@ -305,3 +306,15 @@ new configurations (config from S3).
     ```bash
     aws-vault exec prod-power -- ./bin/scale-remove-old-instances prod ALL
     ```
+
+### No-Migration Recycle
+When responding to a production incident with a config change, or otherwise in a hurry, you might want to recycle without waiting for a migration instance. Note that if a migration has been introduced on main (for environments other than prod), new instances will fail to start until migrations are run.
+1. Recycle the boxes without a migration instance
+```bash
+aws-vault exec prod-power -- ./bin/asg-recycle prod idp --skip-migration
+```
+
+1. In production, remove old IDP instances afterward
+```bash
+aws-vault exec prod-power -- ./bin/scale-remove-old-instances prod ALL
+```

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -37,7 +37,7 @@ Operators can explicitly disable IdV using the `idv_available` configuration key
 # Users will be shown an error message instead.
 idv_available: false
 ```
-For faster results, [recycle without a migration instance](appdev-deploy.md#no-migration-recycle).
+For faster results, [recycle without a migration instance]({% link _articles/appdev-deploy.md %}#no-migration-recycle).
 
 ## Turning off individual vendors
 

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -27,6 +27,8 @@ simply re-edit the configuration and delete the vendor status.
 
 ## Completely disabling identity verification
 
+For a full AAMVA outage, disable identity verification.
+
 Operators can explicitly disable IdV using the `idv_available` configuration key:
 
 ```yaml
@@ -34,6 +36,14 @@ Operators can explicitly disable IdV using the `idv_available` configuration key
 # unsupervised identity verification.
 # Users will be shown an error message instead.
 idv_available: false
+```
+For faster results, recycle without a migration instance.
+```bash
+   aws-vault exec prod-power -- ./bin/asg-recycle prod idp --skip-migration
+```
+and then
+```bash
+  aws-vault exec prod-power -- ./bin/scale-remove-old-instances prod ALL
 ```
 
 ## Turning off individual vendors
@@ -47,6 +57,7 @@ individually. Each is controlled by a configuration flag:
 | LexisNexis| `vendor_status_lexisnexis_instant_verify` <br> `vendor_status_lexisnexis_phone_finder` <br> `vendor_status_lexisnexis_trueid` |
 | Pinpoint | `vendor_status_sms` <br> `vendor_status_voice` |
 
+For a full AAMVA outage, see above to completely disable identity verification
 
 The possible values for each flag:
 

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -37,14 +37,7 @@ Operators can explicitly disable IdV using the `idv_available` configuration key
 # Users will be shown an error message instead.
 idv_available: false
 ```
-For faster results, recycle without a migration instance.
-```bash
-   aws-vault exec prod-power -- ./bin/asg-recycle prod idp --skip-migration
-```
-and then
-```bash
-  aws-vault exec prod-power -- ./bin/scale-remove-old-instances prod ALL
-```
+For faster results, [recycle without a migration instance](appdev-deploy.md#no-migration-recycle).
 
 ## Turning off individual vendors
 


### PR DESCRIPTION
There isn't a specific vendor flag for AAMVA, so direct people to disable IdV completely, and suggest recycling without a migration instance.

This is a followup to an AAMVA outage on August 8, 2023.

See preview of [vendor outage page](https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/sonia-lg-10639-aamva-outage-instructions/articles/vendor-outage-response-process.html) and [appdev deploy page](https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/sonia-lg-10639-aamva-outage-instructions/articles/appdev-deploy.html).