### PR TITLE
Add Timnit daytime oncall details

### DIFF
--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -84,6 +84,8 @@
 
 - name: Timnit
   namesake_markdown: "[Timnit Gebru](https://en.wikipedia.org/wiki/Timnit_Gebru), a computer scientist who has published work exposing biases in AI and algorithms."
+  appdev_oncall_rotation: https://docs.google.com/spreadsheets/d/1Drp-VnMTVwxYyBlTSlPa_cjprGW_rJzxeQHCVAZSKso/edit
+  slack_appdev_oncall_handle: login-oncall-timnit
   focus_area: Document Capture & Authentication
   slack_channel_url: https://gsa-tts.slack.com/archives/C056RD1NEHW
   slack_channel_name: login-team-timnit


### PR DESCRIPTION
**Why?** So that it's available in the ["Team Daytime Oncall" details section](https://handbook.login.gov/articles/appdev-team-daytime-oncall.html#team-oncall-details).

Preview: TBD