### PR TITLE
Extend Cloudwatch dashboard documentation

### DIFF
--- a/_articles/appdev-cloudwatch-dashboard-guide.md
+++ b/_articles/appdev-cloudwatch-dashboard-guide.md
@@ -55,4 +55,6 @@ This will create a terraform file in the devops repo for the dashboard.
 When this file is checked in and applied by terraform a dashboard matching
 the experimental one will be created for all environments.
 
+## Technical Information
+
 For technical information on creating dashboards and alerts, see [Monitoring and observability: CloudWatch queries, alarms and dashboards](https://github.com/18F/identity-devops/wiki/Monitoring-and-observability:-CloudWatch-queries,-alarms-and-dashboards).

--- a/_articles/appdev-cloudwatch-dashboard-guide.md
+++ b/_articles/appdev-cloudwatch-dashboard-guide.md
@@ -45,7 +45,7 @@ The `identity-devops` repo has tooling for converting dashboards to terraformed
 dashboards.
 
 Given an experimental dashboard named `my-sample-dashboard`, run the
-following in the `identity-devops` repo:
+following in the `identity-devops` repo to create `prod-my-sample-dashboard`, `staging-my-sample-dashboard`, etc.:
 
 ```bash
 aws-vault exec prod-power -- bin/copy-cloudwatch-dashboard -i my-sample-dashboard
@@ -54,3 +54,5 @@ aws-vault exec prod-power -- bin/copy-cloudwatch-dashboard -i my-sample-dashboar
 This will create a terraform file in the devops repo for the dashboard.
 When this file is checked in and applied by terraform a dashboard matching
 the experimental one will be created for all environments.
+
+For technical information on creating dashboards and alerts, see [Monitoring and observability: CloudWatch queries, alarms and dashboards](https://github.com/18F/identity-devops/wiki/Monitoring-and-observability:-CloudWatch-queries,-alarms-and-dashboards).

--- a/_articles/devops-scripts.md
+++ b/_articles/devops-scripts.md
@@ -369,6 +369,18 @@ aws-vault exec sandbox-power --
 
 The script can output as new-line delimited JSON (`--json`) or as a CSV (`--csv`).
 
+##  `copy-cloudwatch-dashboard`
+
+Given an experimental dashboard named `my-sample-dashboard`, run the
+following in the `identity-devops` repo to create `prod-my-sample-dashboard`, `staging-my-sample-dashboard`, etc.:
+
+```bash
+aws-vault exec prod-power -- bin/copy-cloudwatch-dashboard -i my-sample-dashboard
+```
+Run it with `--help` for more information on arguments.
+
+See also [Cloudwatch Dashboards]({% link _articles/appdev-cloudwatch-dashboard-guide.md%})
+
 ## `salesforce-email-lookup`
 
 Takes in Salesforce case numbers (escalated from our user support team), and returns


### PR DESCRIPTION
Add link to devops-wiki article on Cloudwatch dashboards to the handbook article. Add copy-cloudwatch-dashboard script to the Scripts page.