### PR TITLE
add new format for daytime oncall user handles

### DIFF
--- a/_articles/appdev-team-daytime-oncall.md
+++ b/_articles/appdev-team-daytime-oncall.md
@@ -14,7 +14,7 @@ subcategory: Oncall
 
 ## Expectations
 
-* Each team's oncall should be reachable by a Slack group handle `@login-TEAM-oncall`.
+* Each team's oncall should be reachable by a Slack group handle `@login-oncall-TEAM`.
 * When issues are escalated to team oncall, the oncall should respond within 15 business minutes.
 * The oncall should fix the issue immediately if it is urgent, or otherwise create a ticket if there is a non-urgent bug to be fixed.
 * "Daytime" is defined as the working hours for the person(s) on the daytime oncall rotation, typically 9am to 5pm in the local time. If an issue is escalated outside working hours, it's expected and understood that the task will be handled the next business day during business hours.

--- a/_data/sprint_teams.yml
+++ b/_data/sprint_teams.yml
@@ -51,7 +51,7 @@
 - name: Katherine
   namesake_markdown: "[Katherine Johnson](https://en.wikipedia.org/wiki/Katherine_Johnson), a mathematician who was a key part of early NASA spaceflights"
   appdev_oncall_rotation: https://docs.google.com/spreadsheets/d/1tAEScH-1A1708a5elOuLDEHj7p_JzFdkpbNGB33gDJU/edit#gid=0
-  slack_appdev_oncall_handle: login-katherine-oncall
+  slack_appdev_oncall_handle: login-oncall-katherine
   focus_area: Authentication
   slack_channel_url: https://gsa-tts.slack.com/archives/C01710KMYUB
   slack_channel_name: login-team-katherine


### PR DESCRIPTION
Why?  So that the daytime oncall page reflects the format settled on in an engineering huddle discussion.

Preview [here](https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/em/update-daytime-oncall/articles/appdev-team-daytime-oncall.html).