### PR TITLE
Clarify language about paging on-call during potential after hours incidents

### DIFF
--- a/_articles/secops-incident-response-guide.md
+++ b/_articles/secops-incident-response-guide.md
@@ -68,7 +68,7 @@ Initial steps:
     * Call in on-call members using the @login-appdev-oncall and @login-devops-oncall handles in Slack
     * Use @here in [#login-situation][login-situation] if still understaffed
   * After hours:
-    * Slack or Splunk On-Call used to alert additional responders (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts) if needed)
+    * Use Splunk On-Call page on-call engineers (See [Emergency Contacts](https://github.com/18F/identity-devops/wiki/On-Call-Guide-Quick-Reference#emergency-contacts)). Please err on the side of caution and page the on-call engineers.
 * Roles are assigned when possible as responders join the incident:
   * **Situation Lead (SL)**: - Responsible for ensuring all following steps are completed. [Situation Lead Checklist]({% link _articles/incident-response-checklist.md %}#situation-lead)
   * **Technical Lead (TL)**: Leads technical investigation and mitigation. [Technical Lead Checklist]({% link _articles/incident-response-checklist.md %}#technical-lead)


### PR DESCRIPTION
Per the action items in incident review [here](https://docs.google.com/document/d/1QzrpcucE84dDkd-E6oul1BzAtcf2a3Ie57TIJJABb-8/edit#heading=h.t4z8dwa4jcc6), this PR aims to add a bit of clarity about paging on-call engineers and how to do it. The linked wiki has also been updated.