### PR TITLE
Hide "Other Articles" heading if there are no other articles

### DIFF
--- a/_includes/articles_category.md
+++ b/_includes/articles_category.md
@@ -30,7 +30,7 @@ includes:
 
 {% assign articles_no_subcategory = site.articles | where: "category", include.category.title | sort: "title" %}
 
-{% if subcategory_articles.size > 1 %}
+{% if articles_no_subcategory.size > 1 %}
 #### Other Articles
 {% endif %}
 


### PR DESCRIPTION
Example: https://handbook.login.gov/categories/development.html

| screenshot |
| --- |
| <img width="460" alt="Screenshot 2023-11-09 at 11 30 42 AM" src="https://github.com/18F/identity-handbook/assets/458784/fecb9756-c1be-428f-add0-6901b89e14d5"> |
