### PR TITLE
Update Definintion of Done and Definition of Ready docs

### DIFF
--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -94,7 +94,7 @@ Key items as part of an acceptance thread:
   - Include steps so that anyone can replicate and review.
   - Specify which environment changes were deployed to, and provide a link to that environment
     - Favor using [Review Apps](https://github.com/18F/identity-devops/wiki/How-to-find-your-review-app) to allow previewing changes before merging to `main`.
-  - Provide screenshots and/or screencast video if possible
+  - Provide screenshots and/or screen recording if possible
   - Sometimes, for tickets that don't have UI changes, includes a description of what changed and links
      to a Pull Request
   - Tag the relevant people for review (including a reference to the ticket number in the notification), generally:

--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -52,7 +52,7 @@ Expect this DoD to change over time.
 
 ## Documentation
 
-- If there is a potential security impact someone has told `@Mo` about it
+- If there is a potential security impact someone has told `#login-security` about it
 - If we are affecting storage or transmission of PII somebody has told the privacy officer `@richard.speidel`
 - The release management guide has been updated for changes to the deploy process
 - The [Entity Relationship Diagrams](https://github.com/18F/identity-idp/blob/main/docs/ARCHITECTURE.md#entity-relationship-diagram) have been updated if the db schema has changed.

--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -55,7 +55,6 @@ Expect this DoD to change over time.
 - If there is a potential security impact someone has told `#login-security` about it
 - If we are affecting storage or transmission of PII somebody has told the privacy officer `@richard.speidel`
 - The release management guide has been updated for changes to the deploy process
-- The [Entity Relationship Diagrams](https://github.com/18F/identity-idp/blob/main/docs/ARCHITECTURE.md#entity-relationship-diagram) have been updated if the db schema has changed.
 - The help content on the static site has been updated and new FAQ content has been created if necessary
 - User journey/interface are connected to user personas and listed in the login handbook.
 

--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -57,6 +57,8 @@ Expect this DoD to change over time.
 - The release management guide has been updated for changes to the deploy process
 - The help content on the static site has been updated and new FAQ content has been created if necessary
 - User journey/interface are connected to user personas and listed in the login handbook.
+- Contact Center scripts and emails have been updated as needed.
+
 
 ## Communications
 
@@ -66,13 +68,13 @@ Expect this DoD to change over time.
 
 ## Acceptance
 
-- PO accepts that user story and acceptance criteria have been fulfilled
+- Product manager accepts that user story and acceptance criteria have been fulfilled
 - Design accepts feature for release to users if applicable
 - Team asserts that all other applicable aspects of the DoD have been met
 
 ### Acceptance Threads
 
-Only Product Owners and Scrum Masters have permission to mark JIRAs as completed. To help them review tickets, we create
+Only Product Owners, Product Managers, and Scrum Masters have permission to mark JIRAs as completed. To help them review tickets, we create
 Acceptance Threads in Slack.
 
 [![screenshot of example thread with labelled key points][image]][image]
@@ -92,7 +94,7 @@ Key items as part of an acceptance thread:
   - Include steps so that anyone can replicate and review.
   - Specify which environment changes were deployed to, and provide a link to that environment
     - Favor using [Review Apps](https://github.com/18F/identity-devops/wiki/How-to-find-your-review-app) to allow previewing changes before merging to `main`.
-  - Provide screenshots if possible
+  - Provide screenshots and/or screencast video if possible
   - Sometimes, for tickets that don't have UI changes, includes a description of what changed and links
      to a Pull Request
   - Tag the relevant people for review (including a reference to the ticket number in the notification), generally:

--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -89,8 +89,9 @@ Key items as part of an acceptance thread:
   - Link to the JIRA ticket
   - Provide a brief description for context since JIRA numbers are not memorable
 - In the thread:
-  - Includes steps so that anyone can replicate and review.
+  - Include steps so that anyone can replicate and review.
   - Specify which environment changes were deployed to, and provide a link to that environment
+    - Favor using [Review Apps](https://github.com/18F/identity-devops/wiki/How-to-find-your-review-app) to allow previewing changes before merging to `main`.
   - Provide screenshots if possible
   - Sometimes, for tickets that don't have UI changes, includes a description of what changed and links
      to a Pull Request

--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -95,6 +95,8 @@ Key items as part of an acceptance thread:
   - Provide screenshots if possible
   - Sometimes, for tickets that don't have UI changes, includes a description of what changed and links
      to a Pull Request
-  - Tag the relevant people for review, usually the Product Manager, Scrum Master, and
-    anybody tagged as a reviewer in the ticket. Include the ticket in the message to help provide
-    context in the notification.
+  - Tag the relevant people for review (including a reference to the ticket number in the notification), generally:
+    - Product Manager
+    - Scrum Master
+    - Anyone tagged as a reviewer in the ticket
+    - A UX team member (if designs were referenced in the ticket)

--- a/_articles/definition-of-ready.md
+++ b/_articles/definition-of-ready.md
@@ -19,13 +19,16 @@ For example:
 
 > As a user, I want to provide consent when an agency partner (sometimes referred to as a service provider or SP) asks how my  information is shared, so that I have full control of what information Login.gov is sharing about me.
 
-Often stories list out **AC**s, or **Acceptance Criteria**. Acceptance Criteria are a set of predefined requirements that must be met for the story to be complete, and describe the change that we will deliver to the user in more detail. For example:
+Stories should list out **AC**s, or **Acceptance Criteria**. Acceptance Criteria are a set of predefined requirements that must be met for the story to be complete, and describe the change that we will deliver to the user in more detail. For example:
 
-> - User is asked for consent when an SP asks for it for the first time only
+> 1. User is asked for consent when an SP asks for it for the first time only
   (either IAL1 or IAL2)
-> - Existing users who are already associated with an SP will be asked for consent
+> 2. Existing users who are already associated with an SP will be asked for consent
   for the freshness value
 
+If a story includes new copy or visual elements, it must include links to wireframes and translations.
+
+A story may also include additional context, including links to related Slack conversations or supporting documents.
 
 ## Bugs
 
@@ -42,7 +45,10 @@ Additional context is always useful, such as:
 - Clear steps to reproduce
 - Potential impact to users
 - Browser and operating system version
-- Links to more information (such as other Jira tickets, customer support inquiries, and/or links to Slack conversation)
+- Links to more information, such as:
+  - Other Jira tickets (including the original story if possible)
+  - Customer support inquiries
+  - Slack conversations
 
 ## Tasks
 

--- a/_articles/definition-of-ready.md
+++ b/_articles/definition-of-ready.md
@@ -32,8 +32,7 @@ A story may also include additional context, including links to related Slack co
 
 ## Bugs
 
-Bugs should clearly explain what is happening, and what should be happening
-instead.
+We use bugs to identify **high priority** issues in production, and they typically take priority over other types of issues. A bug should clearly explain what is happening, and what should be happening instead. A "low priority" bug should be filed as a Task.
 
 For example:
 

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,8 @@
     "triaging",
     "wargame",
     "wargames",
+    "wireframe",
+    "wireframes",
     "yubikey"
   ],
   "patterns": [


### PR DESCRIPTION
Team Ada had a ticket to merge [our team-specific Definition of Done document](https://docs.google.com/document/d/1J_-jcXa6DW4n5vLojNu1zAoUGDin0P9St6af0VlDYWE/edit) into the Login-wide one. This PR does that, with a couple other minor cleanup operations on the way. Hopefully not too controversial. I'm happy to split this into more PRs if anyone has concerns.