### PR TITLE
Remove passenger-restart from partnerships-test-ssns.md

### DIFF
--- a/_articles/partnerships-test-ssns.md
+++ b/_articles/partnerships-test-ssns.md
@@ -31,10 +31,10 @@ This should open the `application.yml` file for the sandbox IdP in your text edi
   test_ssn_allowed_list: '111223333,444556666,777889999'
 ```
 
-Save and quit your text editor and confirm that the diff looks correct to save the file. The changes will take effect when the sandbox environment recycles, which happens automatically most weekdays. If the change needs to take effect immediately, you can restart passenger in the sandbox manually:
+Save and quit your text editor and confirm that the diff looks correct to save the file. The changes will take effect when the sandbox environment recycles, which happens automatically most weekdays. If the change needs to take effect immediately, you can recycle the sandbox environment with this command.
 
 ```sh
-bin/awsv sandbox bin/ssm-command -d passenger-restart -o -r idp -e int
+aws-vault exec sandbox-power -- ./bin/asg-recycle int idp
 ```
 
 [^1]: See our [dev docs](https://developers.login.gov/testing/#personal-information-verification) for more information on this restriction.


### PR DESCRIPTION
The instructions stated to use the passenger restart command which we don't want to use anymore. I replaced it with the sandbox recycle command.