### PR TITLE
LG-11606: Add a table of runbooks to individual vendor runbooks

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -34,12 +34,12 @@ maintenance window, and restart server instances again.
 
 ## Runbooks for individual vendors
 
-| vendor     | runbook                                                                                                    |
-|------------|------------------------------------------------------------------------------------------------------------|
-| AAMVA      | [Runbook for AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook-for-AAMVA-DLDV-outage) |
-| Acuant     | TBD                                                                                                        |
-| LexisNexis | TBD                                                                                                        |
-| Pinpoint   | TBD                                                                                                        |
+| vendor     | runbook                                                                                              |
+|------------|------------------------------------------------------------------------------------------------------|
+| AAMVA      | [Runbook: AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook:-AAMVA-DLDV-outage) |
+| Acuant     | TBD                                                                                                  |
+| LexisNexis | TBD                                                                                                  |
+| Pinpoint   | TBD                                                                                                  |
 
 ## Manually disable identity verification
 

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -32,6 +32,17 @@ Once we have received word that the vendor is back up and running,
 simply re-edit the configuration and delete the vendor status or
 maintenance window, and restart server instances again.
 
+## Runbooks for individual vendors
+
+Runbooks are being written for each vendor to detail how to analyze/test each vendor:
+
+| vendor     | runbook                                                                                                    |
+|------------|------------------------------------------------------------------------------------------------------------|
+| AAMVA      | [Runbook for AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook-for-AAMVA-DLDV-outage) |
+| Acuant     | TBD                                                                                                        |
+| LexisNexis | TBD                                                                                                        |
+| Pinpoint   | TBD                                                                                                        |
+
 ## Manually disable identity verification
 
 For a full AAMVA outage, disable identity verification.
@@ -51,12 +62,12 @@ For faster results, [recycle without a migration instance]({% link _articles/app
 Several vendors or third-party services can be turned off
 individually. Each is controlled by a configuration flag:
 
-| vendor | flag(s) |
-|---------|------|
-| AAMVA | See [manually disable identity verification](#manually-disable-identity-verification) |
-| Acuant  | `vendor_status_acuant` |
-| LexisNexis| `vendor_status_lexisnexis_instant_verify` <br> `vendor_status_lexisnexis_phone_finder` <br> `vendor_status_lexisnexis_trueid` |
-| Pinpoint | `vendor_status_sms` <br> `vendor_status_voice` |
+| vendor     | flag(s)                                                                                                                       |
+|------------|-------------------------------------------------------------------------------------------------------------------------------|
+| AAMVA      | See [manually disable identity verification](#manually-disable-identity-verification)                                         |
+| Acuant     | `vendor_status_acuant`                                                                                                        |
+| LexisNexis | `vendor_status_lexisnexis_instant_verify` <br> `vendor_status_lexisnexis_phone_finder` <br> `vendor_status_lexisnexis_trueid` |
+| Pinpoint   | `vendor_status_sms` <br> `vendor_status_voice`                                                                                |
 
 The possible values for each flag:
 

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -34,8 +34,6 @@ maintenance window, and restart server instances again.
 
 ## Runbooks for individual vendors
 
-Runbooks are being written for each vendor to detail how to analyze/test each vendor:
-
 | vendor     | runbook                                                                                                    |
 |------------|------------------------------------------------------------------------------------------------------------|
 | AAMVA      | [Runbook for AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook-for-AAMVA-DLDV-outage) |


### PR DESCRIPTION
Add a table of runbooks to individual vendor runbooks, of which only AAMVA has been written.

Security > Vendor outage response process > [Runbooks for individual vendors](https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/dprice-lg-11606-aamva-outage-runbook/articles/vendor-outage-response-process.html#runbooks-for-individual-vendors)

Links to the new [Runbook: AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook:-AAMVA-DLDV-outage)