### PR TITLE
LG-11868: add link to LexisNexis Instant Verify outage runbook

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -34,12 +34,14 @@ maintenance window, and restart server instances again.
 
 ## Runbooks for individual vendors
 
-| vendor     | runbook                                                                                              |
-|------------|------------------------------------------------------------------------------------------------------|
-| AAMVA      | [Runbook: AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook:-AAMVA-DLDV-outage) |
-| Acuant     | TBD                                                                                                  |
-| LexisNexis | TBD                                                                                                  |
-| Pinpoint   | TBD                                                                                                  |
+| vendor                    | runbook                                                                                                                            |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| AAMVA                     | [Runbook: AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook:-AAMVA-DLDV-outage)                               |
+| Acuant                    | TBD                                                                                                                                |
+| LexisNexis TrueID         | TBD                                                                                                                                |
+| LexisNexis Instant Verify | [Runbook: LexisNexis Instant Verify outage](https://github.com/18F/identity-devops/wiki/Runbook:-LexisNexis-Instant-Verify-outage) |
+| LexisNexis Phone Finder   | TBD                                                                                                                                |
+| Pinpoint                  | TBD                                                                                                                                |
 
 ## Manually disable identity verification
 


### PR DESCRIPTION
Adds the new Instant Verify runbook to the table of individual vendor runbooks.

Security > Vendor outage response process > [Runbooks for individual vendors](https://federalist-7d0b2b76-42fc-4df1-9825-8c3cd77e0a15.sites.pages.cloud.gov/preview/18f/identity-handbook/dprice-lg-11868-ln-iv-outage-runbook/articles/vendor-outage-response-process.html#runbooks-for-individual-vendors)

Links to the new [Runbook: LexisNexis Instant Verify outage](https://github.com/18F/identity-devops/wiki/Runbook:-LexisNexis-Instant-Verify-outage)