### PR TITLE
Add note about rolling back failed deploys

### DIFF
--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -255,6 +255,8 @@ To quickly remove new servers and leave old servers up:
 aws-vault exec prod-power -- ./bin/scale-remove-new-instances prod ALL
 ```
 
+As soon as possible, ensure that the deploy is rolled back by reverting the `stages/prod` branch in GitHub by following the steps below. This is important because new instances can start at any time to accommodate increased traffic, and in response to other recycle operations like configuration changes.
+
 ##### Steps to roll back
 
 1. Make a pull request to the `stages/prod` branch, to revert it back to the last deploy.

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -257,7 +257,7 @@ aws-vault exec prod-power -- ./bin/scale-remove-new-instances prod ALL
 
 **Important:**
 
-As soon as possible, ensure that the deploy is rolled back by reverting the `stages/prod` branch in GitHub by following the steps below. This is important because new instances can start at any time to accommodate increased traffic, and in response to other recycle operations like configuration changes.
+As soon as possible, ensure that the deploy is rolled back by reverting the `stages/prod` branch in GitHub by following the [steps to roll back](#steps-to-roll-back) below. This is important because new instances can start at any time to accommodate increased traffic, and in response to other recycle operations like configuration changes.
 
 ##### Steps to roll back
 

--- a/_articles/appdev-deploy.md
+++ b/_articles/appdev-deploy.md
@@ -255,6 +255,8 @@ To quickly remove new servers and leave old servers up:
 aws-vault exec prod-power -- ./bin/scale-remove-new-instances prod ALL
 ```
 
+**Important:**
+
 As soon as possible, ensure that the deploy is rolled back by reverting the `stages/prod` branch in GitHub by following the steps below. This is important because new instances can start at any time to accommodate increased traffic, and in response to other recycle operations like configuration changes.
 
 ##### Steps to roll back


### PR DESCRIPTION
This adds a small note to clarify that terminating a deploy should usually be followed up with reverting the branch 