### PR TITLE
update README with additional instructions for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ article and it will be automatically linked to from the index of all articles.
 
 ## Running Locally
 
+Ensure that you have the concurrently CLI helper installed.
+
+```
+npm i -g concurrently
+```
+
 ```
 make run
 ```
+
+Open http://127.0.0.1:4000/ in a browser.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ article and it will be automatically linked to from the index of all articles.
 
 ## Running Locally
 
-Ensure that you have the concurrently CLI helper installed.
+Ensure that you have the required dependencies installed.
 
 ```
-npm i -g concurrently
+make setup
 ```
 
 ```
 make run
 ```
 
-Open http://127.0.0.1:4000/ in a browser.
+Open http://localhost:4000/ in a browser, or run `open http://localhost:4000` from the MacOS CLI.
 
 ## Running Tests
 


### PR DESCRIPTION
Title says it all. This is part of the follow up from the [incident review](https://docs.google.com/document/d/1j5ihCdAZUssQN9Y9KevvOEqFcBXU48Iz_66JF9yVE28/edit#heading=h.yjzagco8hnao) for the login.gov brochure outage.