### PR TITLE
LG-12244: Add link to LexisNexis TrueID outage runbook

### DIFF
--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -77,17 +77,16 @@ individually. Each is controlled by a configuration flag:
 The possible values for each flag:
 
 - `operational`
-- `partial_outage`
 - `full_outage`
 
 The default value for each of the flags is `operational`.
 
-When one or more of the flags are set to `full_outage` or `partial_outage`, some parts of
+When one or more of the flags are set to `full_outage`, some parts of
 identity verification will be disabled.
 
 As an overview:
 
-- Setting `full_outage` or `partial_outage` for `acuant`, `lexisnexis_instant_verify`, or
+- Setting `full_outage` for `acuant`, `lexisnexis_instant_verify`, or
   `lexisnexis_trueid` turns off pretty much everything. Identity verification
   is completely unavailable.
 

--- a/_articles/vendor-outage-response-process.md
+++ b/_articles/vendor-outage-response-process.md
@@ -38,7 +38,7 @@ maintenance window, and restart server instances again.
 |---------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | AAMVA                     | [Runbook: AAMVA DLDV outage](https://github.com/18F/identity-devops/wiki/Runbook:-AAMVA-DLDV-outage)                               |
 | Acuant                    | TBD                                                                                                                                |
-| LexisNexis TrueID         | TBD                                                                                                                                |
+| LexisNexis TrueID         | [Runbook: LexisNexis TrueID outage](https://github.com/18F/identity-devops/wiki/Runbook%3A-LexisNexis-TrueID-outage)               |
 | LexisNexis Instant Verify | [Runbook: LexisNexis Instant Verify outage](https://github.com/18F/identity-devops/wiki/Runbook:-LexisNexis-Instant-Verify-outage) |
 | LexisNexis Phone Finder   | TBD                                                                                                                                |
 | ThreatMetrix              | [Runbook: ThreatMetrix outage](https://github.com/18F/identity-devops/wiki/Runbook:-ThreatMetrix-outage)
@@ -77,16 +77,17 @@ individually. Each is controlled by a configuration flag:
 The possible values for each flag:
 
 - `operational`
+- `partial_outage`
 - `full_outage`
 
 The default value for each of the flags is `operational`.
 
-When one or more of the flags are set to `full_outage`, some parts of
+When one or more of the flags are set to `full_outage` or `partial_outage`, some parts of
 identity verification will be disabled.
 
 As an overview:
 
-- Setting `full_outage` for `acuant`, `lexisnexis_instant_verify`, or
+- Setting `full_outage` or `partial_outage` for `acuant`, `lexisnexis_instant_verify`, or
   `lexisnexis_trueid` turns off pretty much everything. Identity verification
   is completely unavailable.
 


### PR DESCRIPTION
[LG-12244](https://cm-jira.usa.gov/browse/LG-12244)

Added a link to the new LexisNexis TrueID outage runbook.

Also added the other possibility for `VENDOR_STATUS_OPTIONS`, [which I found](https://github.com/18F/identity-idp/blob/cf8764c2be19a834c3c7116d35bfccb44de41938/lib/identity_config.rb#L6) in my research for creating the runbook.

I didn't find any behavioral difference between `full_outage` and `partial_outage` in my local testing, though I could've missed something.