### PR TITLE
Remove design.login.gov reference from DOD

### DIFF
--- a/_articles/definition-of-done.md
+++ b/_articles/definition-of-done.md
@@ -40,7 +40,7 @@ Expect this DoD to change over time.
 - Interface and user journey changes are approved by the UX Team in order to release the story to production, or the story is controlled by a Feature Flag. Changes are approved by relevant SMEs to ensure consistency and quality of our product.
 - If a usability test is needed, a Jira task to develop a usability testing plan has been created.
 - Conforms to Section 508 standards by both manual and automated scanning methods.
-- The new design uses components from the Login Design System (design.login.gov, Figma).
+- The new design uses components from the [Login.gov Design System](https://github.com/18f/identity-design-system/).
 - Notify the Design System UX SME and Design System Manager when a new design component is not yet in the design system, so it can be considered.
 - Visual graphics and mockups are saved in the relevant Figma shared folder (example: Identity, Authentication). Research artifacts, content, translations, and sensitive artifacts are saved in [the shared Login.gov User Experience Google Drive folder](https://drive.google.com/drive/folders/12qRTGijG9oOU8FRvZfK30qAN4v8LCzHG).
 - For UX Tasks: implementation and/or testing tickets should be created in Jira for the next step to complete the work or hand off to the next phase.

--- a/_articles/onboarding.md
+++ b/_articles/onboarding.md
@@ -21,7 +21,7 @@ Each Login.gov team has their own personalized [GDoc/Onboarding Template / Check
 - Watch a [Login.gov identity verification overview](https://drive.google.com/file/d/1GanUUpkAcJCopQAPac4DSe10LREdSGZw/view)
 - Watch a [Login.gov security overview](https://drive.google.com/file/d/1ZR4uin3dJZmq7nOvgROcv95_mcRPmx0n/view?usp=sharing)
 - Review the [Login.gov org chart](https://docs.google.com/spreadsheets/d/1tiTR2ohdl0NIsrF4gJjNipEZ0z0oq1pOFWYjHg8Tbi0/edit#gid=0)
-- Review the [Login.gov Design System](https://design.login.gov/)
+- Review the [Login.gov Design System](https://github.com/18f/identity-design-system/)
 - Complete [GSA OLU](https://insite.gsa.gov/topics/training-and-development/online-university-olu?term=olu) IT Security Awareness Training, including accepting the GSA IT Rules of Behavior, which is required before we can give you access to any Login.gov systems. If you joined GSA more than two months ago, you’ve already completed this task. (Detailees must complete similar organization driven training and provide as proof to Login.gov team members)
 - Schedule virtual tea/coffee meetings with your team lead, other members of your team, and anyone else!  Tea is just a short (~20 min) one-on-one video meeting with the purpose of getting to know each other.
 - Once you've been added to Slack:


### PR DESCRIPTION
**What:**
I came across a `design.login.gov` reference while reviewing the definition of done page. 

Removing since it doesn't exist anymore while replacing it with a link to the the LGDS repository.