### PR TITLE
Removing link referencing language in Defending Women EO

### DIFF
--- a/_articles/biannual-review.md
+++ b/_articles/biannual-review.md
@@ -57,7 +57,7 @@ Your Team lead will:
 
 ### Writing Reviews
 
-- TTS has a very helpful [training deck on recognizing bias and creating equity in performance reviews](https://docs.google.com/presentation/d/1Jn_cEVhxJ4Vzmj0pJOnjxHYXp5xoMUHyCbyFl1foPXw/edit#slide=id.p). Please review it.
+- TTS has a very helpful training deck on recognizing bias and creating equity in performance reviews. Please review it.
 - Spend some time thinking about the raw feedback for each person, and the shape of review it defines. Make some notes. Review content should be ~ 98% Self Review and Peer Feedback content -- edited by you for clarity.
 - Spend some time thinking about aligning and normalizing the feedback across all of the people on your team. Review your notes.
 - Use provided templates to create your review documents


### PR DESCRIPTION
At the direction of the Assistant Commissioners, removing a link that references language in Sec. 3 (c) and Sec. 3 (e) of the Executive Order on Defending Women.

## 🛠 Summary of changes

At the direction of the Assistant Commissioners, removing a link that references language in Sec. 3 (c) and Sec. 3 (e) of the Executive Order on Defending Women.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Load page and see if the text "TTS has a very helpful training deck on recognizing bias and creating equity in performance reviews" has a link.