### PR TITLE
Fix typo in Cloudwatch query

### DIFF
--- a/_articles/appdev-troubleshooting-production.md
+++ b/_articles/appdev-troubleshooting-production.md
@@ -140,7 +140,7 @@ We don't have indexed lookups by phone number so we need to combine a few approa
    fields
      properties.user_id,
      @timestamp
-   | filter name = 'Telephoy: OTP sent'
+   | filter name = 'Telephony: OTP sent'
    | filter properties.event_properties.phone_fingerprint in ["aaa", "bbb", "ccc"] # CHANGE THIS
    ```
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🛠 Summary of changes

Fixes a typo in the event name `Telephony: OTP sent` for a Cloudwatch query.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
-->
